### PR TITLE
Ignore join accept message if already joined

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1296,6 +1296,11 @@ static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t
     switch( macHdr.Bits.MType )
     {
         case FRAME_TYPE_JOIN_ACCEPT:
+            if (IsLoRaMacNetworkJoined) {
+              // already joined to network, ignore join accept message
+              break;
+            }
+        
             LoRaMacJoinDecrypt( payload + 1, size - 1, LoRaMacAppKey, LoRaMacPayload + 1 );
 
             LoRaMacPayload[0] = macHdr.Value;


### PR DESCRIPTION
There could be an instance when a join accept message is received inadvertently, then a new address would be assigned and new keys computed.