### PR TITLE
Weird conditions to check datarate on cmd mac SRV_MAC_NEW_CHANNEL_REQ

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1191,11 +1191,11 @@ static void LoRaMacProcessMacCommands( uint8_t *payload, uint8_t macIndex, uint8
                         status &= 0xFE; // Channel frequency KO
                     }
 
-                    if( ( chParam.DrRange.Fields.Min > chParam.DrRange.Fields.Max ) &&
-                        ( ( LORAMAC_MIN_DATARATE <= chParam.DrRange.Fields.Min ) &&
-                          ( chParam.DrRange.Fields.Min <= LORAMAC_MAX_DATARATE ) == false ) &&
-                        ( ( LORAMAC_MIN_DATARATE <= chParam.DrRange.Fields.Max ) &&
-                          ( chParam.DrRange.Fields.Max <= LORAMAC_MAX_DATARATE ) == false ) )
+                    if( ( chParam.DrRange.Fields.Min > chParam.DrRange.Fields.Max ) ||
+                        ( ( ( LORAMAC_MIN_DATARATE <= chParam.DrRange.Fields.Min ) &&
+                            ( chParam.DrRange.Fields.Min <= LORAMAC_MAX_DATARATE ) ) == false ) ||
+                        ( ( ( LORAMAC_MIN_DATARATE <= chParam.DrRange.Fields.Max ) &&
+                            ( chParam.DrRange.Fields.Max <= LORAMAC_MAX_DATARATE ) ) == false ) )
                     {
                         status &= 0xFD; // Datarate range KO
                     }


### PR DESCRIPTION
status should be set to "// Datarate range KO" if any of these condition is true
        min datarate > max datarate
        min datarate not in the range
        max datarate not in the range