### PR TITLE
Correct ChannelCheckTimerEvent to send when tx NOT running

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -542,7 +542,7 @@ void OnChannelCheckTimerEvent( void )
     LoRaMacState &= ~MAC_CHANNEL_CHECK;
     if( LoRaMacSetNextChannel( ) == 0 )
     {
-        if( ( LoRaMacState & MAC_TX_RUNNING ) == MAC_TX_RUNNING )
+        if( ( LoRaMacState & MAC_TX_RUNNING ) != MAC_TX_RUNNING )
         {
            LoRaMacSendFrameOnChannel( Channels[Channel] );
         }


### PR DESCRIPTION
ChannelCheckTimerEvent should call LoRaMacSendFrameOnChannel when free channel found and MAC_TX_RUNNING bit is NOT set