### PR TITLE
Avoid duplicate uplink sequence numbers when receiving bad MIC or add…

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2283,6 +2283,14 @@ static void OnMacStateCheckTimerEvent( void )
                     LoRaMacSendFrameOnChannel( Channels[Channel] );
                 }
             }
+        } else {
+                /*
+                 * For confirmed uplinks, ignore MIC and address errors and keep retrying.
+                 */
+                if ((LoRaMacEventInfo.Status == LORAMAC_EVENT_INFO_STATUS_MIC_FAIL) ||
+                    (LoRaMacEventInfo.Status == LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL)) {
+                AckTimeoutRetry = true;
+            }
         }
 
         if( LoRaMacEventFlags.Bits.Rx == 1 )

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1898,9 +1898,16 @@ static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t
                     if( LoRaMacEventFlags.Bits.Multicast == 0 )
                     {
                         // We are not the destination of this frame.
-                        LoRaMacEventFlags.Bits.Tx = 1;
-                        LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
-                        LoRaMacState &= ~MAC_TX_RUNNING;
+                        // Ignore for confirmed messages.
+                        if (NodeAckRequested == true) {
+                            if( LoRaMacEventFlags.Bits.RxSlot == 0 ) {
+                                OnRxWindow2TimerEvent( );
+                            }
+                        } else {
+                            LoRaMacEventFlags.Bits.Tx = 1;
+                            LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
+                            LoRaMacState &= ~MAC_TX_RUNNING;
+                        }
                         return;
                     }
                 }
@@ -2039,11 +2046,19 @@ static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t
                 }
                 else
                 {
-                    LoRaMacEventInfo.TxAckReceived = false;
-                    
-                    LoRaMacEventFlags.Bits.Tx = 1;
-                    LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
-                    LoRaMacState &= ~MAC_TX_RUNNING;
+                    // The frame has a MIC error.
+                    // Ignore for confirmed messages.
+                    if (NodeAckRequested == true) {
+                        if( LoRaMacEventFlags.Bits.RxSlot == 0 ) {
+                            OnRxWindow2TimerEvent( );
+                        }
+                    } else {
+                        LoRaMacEventInfo.TxAckReceived = false;
+
+                        LoRaMacEventFlags.Bits.Tx = 1;
+                        LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
+                        LoRaMacState &= ~MAC_TX_RUNNING;
+                    }
                 }
             }
             break;

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1898,16 +1898,9 @@ static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t
                     if( LoRaMacEventFlags.Bits.Multicast == 0 )
                     {
                         // We are not the destination of this frame.
-                        // Ignore for confirmed messages.
-                        if (NodeAckRequested == true) {
-                            if( LoRaMacEventFlags.Bits.RxSlot == 0 ) {
-                                OnRxWindow2TimerEvent( );
-                            }
-                        } else {
-                            LoRaMacEventFlags.Bits.Tx = 1;
-                            LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
-                            LoRaMacState &= ~MAC_TX_RUNNING;
-                        }
+                        LoRaMacEventFlags.Bits.Tx = 1;
+                        LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
+                        LoRaMacState &= ~MAC_TX_RUNNING;
                         return;
                     }
                 }
@@ -2046,19 +2039,11 @@ static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t
                 }
                 else
                 {
-                    // The frame has a MIC error.
-                    // Ignore for confirmed messages.
-                    if (NodeAckRequested == true) {
-                        if( LoRaMacEventFlags.Bits.RxSlot == 0 ) {
-                            OnRxWindow2TimerEvent( );
-                        }
-                    } else {
-                        LoRaMacEventInfo.TxAckReceived = false;
-
-                        LoRaMacEventFlags.Bits.Tx = 1;
-                        LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
-                        LoRaMacState &= ~MAC_TX_RUNNING;
-                    }
+                    LoRaMacEventInfo.TxAckReceived = false;
+                    
+                    LoRaMacEventFlags.Bits.Tx = 1;
+                    LoRaMacEventInfo.Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
+                    LoRaMacState &= ~MAC_TX_RUNNING;
                 }
             }
             break;


### PR DESCRIPTION
…ress in confirmed transmits.

If during a confirmed message transmission we receive a downlink frame with either
an address not matching ours, or an incorrect MIC, control is returned to the user
application with an error status, and the upLinkCounter is not incremented. Thus,
the next uplink frame is sent with the same sequence number, and likely discarded
by the receiving server.

The fix involves discarding the invalid downlink and continuing the retransmission
of the uplink frame until either a downlink response/ack is received, or the retry
count is reached.