### PR TITLE
MAC fails to transmit maximum length (242 bytes) payload

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -20,7 +20,7 @@ Maintainer: Miguel Luis and Gregory Cristian
 /*!
  * Maximum PHY layer payload size
  */
-#define LORAMAC_PHY_MAXPAYLOAD                      250
+#define LORAMAC_PHY_MAXPAYLOAD                      255
 
 /*!
  * Device IEEE EUI


### PR DESCRIPTION
Attempting to transmit the maximum allowed length payload for a
given data rate fails with a return code 3 for 242 byte payloads.
