### PR TITLE
Fixed typo in LoRaMac header

### DIFF
--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -318,10 +318,10 @@ typedef struct sLoRaMacCallbacks
 /*!
  * LoRaMAC layer initialization
  *
- * \param [IN] callabcks       Pointer to a structure defining the LoRaMAC
+ * \param [IN] callbacks       Pointer to a structure defining the LoRaMAC
  *                             callback functions.
  */
-void LoRaMacInit( LoRaMacCallbacks_t *callabcks );
+void LoRaMacInit( LoRaMacCallbacks_t *callbacks );
 
 /*!
  * Enables/Disables the ADR (Adaptive Data Rate)


### PR DESCRIPTION
Either this is a typo, or I don't know what `callabcks` are...