### PR TITLE
Issues on data rate back off

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1389,6 +1389,8 @@ static void OnMacStateCheckTimerEvent( void )
 
                 McpsConfirm.AckReceived = false;
                 McpsConfirm.NbRetries = AckTimeoutRetriesCounter;
+
+                AdrAckCounter++;
                 if( IsUpLinkCounterFixed == false )
                 {
                     UpLinkCounter++;
@@ -1805,11 +1807,10 @@ static bool DisableChannelInMask( uint8_t id, uint16_t* mask )
 static bool AdrNextDr( bool adrEnabled, bool updateChannelMask, int8_t* datarateOut )
 {
     bool adrAckReq = false;
-    int8_t datarate = ChannelsDatarate;
 
     if( adrEnabled == true )
     {
-        if( datarate == LORAMAC_MIN_DATARATE )
+        if( ChannelsDatarate == LORAMAC_MIN_DATARATE )
         {
             AdrAckCounter = 0;
             adrAckReq = false;
@@ -1856,18 +1857,18 @@ static bool AdrNextDr( bool adrEnabled, bool updateChannelMask, int8_t* datarate
             {
                 AdrAckCounter = 0;
 #if defined( USE_BAND_433 ) || defined( USE_BAND_780 ) || defined( USE_BAND_868 )
-                if( datarate > LORAMAC_MIN_DATARATE )
+                if( ChannelsDatarate > LORAMAC_MIN_DATARATE )
                 {
-                    datarate--;
+                    ChannelsDatarate--;
                 }
 #elif defined( USE_BAND_915 ) || defined( USE_BAND_915_HYBRID )
-                if( ( datarate > LORAMAC_MIN_DATARATE ) && ( datarate == DR_8 ) )
+                if( ( ChannelsDatarate > LORAMAC_MIN_DATARATE ) && ( ChannelsDatarate == DR_8 ) )
                 {
-                    datarate = DR_4;
+                    ChannelsDatarate = DR_4;
                 }
-                else if( datarate > LORAMAC_MIN_DATARATE )
+                else if( ChannelsDatarate > LORAMAC_MIN_DATARATE )
                 {
-                    datarate--;
+                    ChannelsDatarate--;
                 }
 #else
 #error "Please define a frequency band in the compiler options."
@@ -1876,7 +1877,7 @@ static bool AdrNextDr( bool adrEnabled, bool updateChannelMask, int8_t* datarate
         }
     }
 
-    *datarateOut = datarate;
+    *datarateOut = ChannelsDatarate;
 
     return adrAckReq;
 }


### PR DESCRIPTION
There is three main point, the first is about AdrAckReq and confirmed frames, the second on AdrAckReq that is not applied, and the third is a question about a point unclear from LoRaWan specifications.

A)
Currently, AdrAckReq is used only for unconfirmed frames. AdrAckCounter is incremented only when sending unconfirmed, and is reset
It should be used for confirmed and unconfirmed frames. Imagine a situation where the device is configured with :
 - using adaptive data rate (ADR enabled)
 - confirmed frame with one or two emission (nbRetries=1 or nbRetries=2),
 - it has data rate higher than its default data rate,
 - it does not get any acknowledgment for a reason or another,
This device will never do an adrBackOff to lower its data rate.

B)
DrBackOff on an AdrAckReq and AdrAckReqCounter is done in function AdrNextDr. There is an issue where the function is called before the next tx by function LoRaMacQueryTxPossible (line 2668) that does not store result in ChannelsDatarate. So the back off is ignored.
For various reason I call this function to get the size possible for the next frame at every emission. So when it does need to lower the data rate, it is not done.

C)
AdrAckReq is managed using constants  ADR_ACK_LIMIT = 64 and ADR_ACK_DELAY = 32.
When the device does not get downlink on  ADR_ACK_LIMIT frames it will activate the AdrAckReq bit. If it does not get a downlink for ADR_ACK_DELAY frames it will reduce it's data rate (if possible) and start again.
The question is: why does it start again from 0 as it has not get any downlink for now 64+32 frames ? Would it be better if it restart with the counter directly set at  ADR_ACK_LIMIT to set again the bit AdrAckReq during  ADR_ACK_DELAY frames. The point is to get an acknowledgement from any gateway as soon as possible to loose less data. With the current model a device can loose up to 480 frames before getting back to DR_0 (SF_12). (96 for each data rate starting at DR_5 (SF_7))