### PR TITLE
Update sx1276Regs-Fsk.h add modulation shaping names in RegPaRamp register

### DIFF
--- a/src/radio/sx1276/sx1276Regs-Fsk.h
+++ b/src/radio/sx1276/sx1276Regs-Fsk.h
@@ -376,9 +376,15 @@ Maintainer: Miguel Luis and Gregory Cristian
 /*!
  * RegPaRamp
  */
-#define RF_PARAMP_LOWPNTXPLL_MASK                   0xE0
-#define RF_PARAMP_LOWPNTXPLL_OFF                    0x10  // Default
-#define RF_PARAMP_LOWPNTXPLL_ON                     0x00
+#define RF_PARAMP_MODULATIONSHAPING_MASK            0x9F
+#define RF_PARAMP_MODULATIONSHAPING_00              0x00 // Default
+#define RF_PARAMP_MODULATIONSHAPING_01              0x20
+#define RF_PARAMP_MODULATIONSHAPING_10              0x40
+#define RF_PARAMP_MODULATIONSHAPING_11              0x60
+
+#define RF_PARAMP_LOWPNTXPLL_MASK                   0xEF
+#define RF_PARAMP_LOWPNTXPLL_OFF                    0x10
+#define RF_PARAMP_LOWPNTXPLL_ON                     0x00  // Default
 
 #define RF_PARAMP_MASK                              0xF0
 #define RF_PARAMP_3400_US                           0x00


### PR DESCRIPTION

and fix LOWPNTXPLL mask and default value as on SX1276 datasheet and former sx1276-Fsk.h file