### PR TITLE
Timer list null pointer fix

### DIFF
--- a/src/system/timer.c
+++ b/src/system/timer.c
@@ -200,6 +200,12 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
 void TimerIrqHandler( void )
 {
     uint32_t elapsedTime = 0;
+    
+    // Early out when TimerListHead is null to prevent nullpointer
+    if ( TimerListHead == NULL ) 
+    {
+        return;
+    }
 
     elapsedTime = TimerGetValue( );
     


### PR DESCRIPTION
It is possible for the timer list to be empty, so we need to check for null pointer in this interrupt request.
