### PR TITLE
sx1276.c: fixed CadDone DIO0 to DIO3 interrupt mapping

### DIFF
--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -1161,7 +1161,7 @@ void SX1276StartCad( void )
                                         );
 
             // DIO3=CADDone
-            SX1276Write( REG_DIOMAPPING1, ( SX1276Read( REG_DIOMAPPING1 ) & RFLR_DIOMAPPING1_DIO0_MASK ) | RFLR_DIOMAPPING1_DIO0_00 );
+            SX1276Write( REG_DIOMAPPING1, ( SX1276Read( REG_DIOMAPPING1 ) & RFLR_DIOMAPPING1_DIO3_MASK ) | RFLR_DIOMAPPING1_DIO3_00 );
 
             SX1276.Settings.State = RF_CAD;
             SX1276SetOpMode( RFLR_OPMODE_CAD );


### PR DESCRIPTION
According to the [Table 18](http://www.semtech.com/images/datasheet/sx1276_77_78_79.pdf#G7.1318367) in SX1276 [Datasheet](http://www.semtech.com/images/datasheet/sx1276_77_78_79.pdf), the CadDone interrupt is sitting on the DIO3 line, but we're setting some bits in DIO0 mapping instead.