### PR TITLE
Fix RxDone FIFO read addr for RX Continuous mode

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -1374,6 +1374,7 @@ void SX1272OnDio0Irq( void )
                     }
 
                     SX1272.Settings.LoRaPacketHandler.Size = SX1272Read( REG_LR_RXNBBYTES );
+                    SX1272Write( REG_LR_FIFOADDRPTR, SX1272Read( REG_LR_FIFORXCURRENTADDR ) );
                     SX1272ReadFifo( RxTxBuffer, SX1272.Settings.LoRaPacketHandler.Size );
 
                     if( SX1272.Settings.LoRa.RxContinuous == false )

--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -1551,6 +1551,7 @@ void SX1276OnDio0Irq( void )
                     }
 
                     SX1276.Settings.LoRaPacketHandler.Size = SX1276Read( REG_LR_RXNBBYTES );
+                    SX1276Write( REG_LR_FIFOADDRPTR, SX1276Read( REG_LR_FIFORXCURRENTADDR ) );
                     SX1276ReadFifo( RxTxBuffer, SX1276.Settings.LoRaPacketHandler.Size );
 
                     if( SX1276.Settings.LoRa.RxContinuous == false )


### PR DESCRIPTION
The host FifoAddrPtr is not set before reading the RX payload in the RXDone IRQ (SX1276OnDio0Irq).
Although this works for receiving a single packet and then toggling through standby or sleep operating modes (resetting FIFO address registers), this does not work for actually using RX Continuous mode, where the REG_LR_FIFORXCURRENTADDR location is constantly changing.

Here we set the FIFO Pointer address to the head of the current RX payload before reading the RX payload, as per the datasheet.