### PR TITLE
SX1272 Continuous RX Fix

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -1374,6 +1374,10 @@ void SX1272OnDio0Irq( void )
                     }
 
                     SX1272.Settings.LoRaPacketHandler.Size = SX1272Read( REG_LR_RXNBBYTES );
+                    // Make sure we read from the correct fifo offset if in continuous receive mode, as incoming data wraps
+                    if (SX1272.Settings.LoRa.RxContinuous == true) {
+                        SX1272Write(REG_LR_FIFOADDRPTR, SX1272Read(REG_LR_FIFORXCURRENTADDR));
+                    }
                     SX1272ReadFifo( RxTxBuffer, SX1272.Settings.LoRaPacketHandler.Size );
 
                     if( SX1272.Settings.LoRa.RxContinuous == false )


### PR DESCRIPTION
Continuous RX mode in the SX1272 driver was not advancing the FIFO ringbuffer pointer after reading a packet, causing the next read request to re-read starting from the beginning of the prior packet. Advancing the FIFOADDRPTR to the position of the FIFORXCURRENTADDR pointer fixes this.