### PR TITLE
Mote II RTC module refactoring

### DIFF
--- a/src/apps/ping-pong/MoteII/main.c
+++ b/src/apps/ping-pong/MoteII/main.c
@@ -28,6 +28,10 @@ Maintainer: Miguel Luis and Gregory Cristian
 
 #define RF_FREQUENCY                                779000000 // Hz
 
+#elif defined( REGION_EU433 )
+
+#define RF_FREQUENCY                                434000000 // Hz
+
 #elif defined( REGION_EU868 )
 
 #define RF_FREQUENCY                                868000000 // Hz

--- a/src/boards/MoteII/board.c
+++ b/src/boards/MoteII/board.c
@@ -378,6 +378,9 @@ void SystemClockConfig( void )
         assert_param( FAIL );
     }
 
+    // Recalculate the SystemCoreClock global variable
+    SystemCoreClockUpdate( );
+
     HAL_SYSTICK_Config( HAL_RCC_GetHCLKFreq( ) / 1000 );
 
     HAL_SYSTICK_CLKSourceConfig( SYSTICK_CLKSOURCE_HCLK );
@@ -391,9 +394,6 @@ void SystemClockConfig( void )
 #else
     __HAL_RCC_DBGMCU_CLK_DISABLE( );
 #endif
-
-    // Recalculate the SystemCoreClock global variable
-    SystemCoreClockUpdate( );
 }
 
 void CalibrateSystemWakeupTime( void )

--- a/src/boards/MoteII/board.c
+++ b/src/boards/MoteII/board.c
@@ -385,6 +385,13 @@ void SystemClockConfig( void )
     // SysTick_IRQn interrupt configuration
     HAL_NVIC_SetPriority( SysTick_IRQn, 0, 0 );
 
+    // Configure the microcontroller's Debug peripheral clock
+#if defined( DEBUG )
+    __HAL_RCC_DBGMCU_CLK_ENABLE( );
+#else
+    __HAL_RCC_DBGMCU_CLK_DISABLE( );
+#endif
+
     // Recalculate the SystemCoreClock global variable
     SystemCoreClockUpdate( );
 }

--- a/src/boards/MoteII/board.c
+++ b/src/boards/MoteII/board.c
@@ -384,6 +384,9 @@ void SystemClockConfig( void )
 
     // SysTick_IRQn interrupt configuration
     HAL_NVIC_SetPriority( SysTick_IRQn, 0, 0 );
+
+    // Recalculate the SystemCoreClock global variable
+    SystemCoreClockUpdate( );
 }
 
 void CalibrateSystemWakeupTime( void )
@@ -428,6 +431,9 @@ void SystemClockReConfig( void )
     while( __HAL_RCC_GET_SYSCLK_SOURCE( ) != RCC_SYSCLKSOURCE_STATUS_PLLCLK )
     {
     }
+
+    // Recalculate the SystemCoreClock global variable
+    SystemCoreClockUpdate( );
 }
 
 void SysTick_Handler( void )

--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -197,8 +197,6 @@ void RtcInit( void )
 
     if( RtcInitialized == false )
     {
-        __HAL_RCC_RTC_ENABLE( );
-
         RtcHandle.Instance = RTC;
         RtcHandle.Init.HourFormat = RTC_HOURFORMAT_24;
         RtcHandle.Init.AsynchPrediv = PREDIV_A; // RTC_ASYNCH_PREDIV;
@@ -376,7 +374,7 @@ void RtcEnterLowPowerStopMode( void )
         // SysTick interrupt would wake up the MCU for every tick
         HAL_SuspendTick();
 
-        // Enter Stop Mode        
+        // Enter Stop Mode
 #if defined(DEBUG)
         HAL_PWR_EnterSTOPMode( PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI );
 #else
@@ -856,6 +854,22 @@ static RtcCalendar_t RtcGetCalendar( void )
     }
     HAL_RTC_GetDate( &RtcHandle, &now.CalendarDate, RTC_FORMAT_BIN );
     return( now );
+}
+
+void HAL_RTC_MspInit( RTC_HandleTypeDef *rtcHandle )
+{
+    if( rtcHandle->Instance == RTC )
+    {
+        __HAL_RCC_RTC_ENABLE( );
+    }
+}
+
+void HAL_RTC_MspDeInit( RTC_HandleTypeDef *rtcHandle )
+{
+    if( rtcHandle->Instance == RTC )
+    {
+        __HAL_RCC_RTC_DISABLE( );
+    }
 }
 
 /*!

--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -536,6 +536,8 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
 
     for ( ;; )
     {
+        uint8_t cont = 0;
+
         if( year % 4 == 0 )
         {
             while( day > DaysInMonthLeapYear[month - 1] )
@@ -548,9 +550,15 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
                     month -= 12;
                     year++;
 
-                    // Year was changed, start from the scratch
-                    continue;
+                    cont = 1;
+                    break;
                 }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
             }
 
             // Calculations done
@@ -568,9 +576,15 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
                     month -= 12;
                     year++;
 
-                    // Year was changed, start from the scratch
-                    continue;
+                    cont = 1;
+                    break;
                 }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
             }
 
             // Calculations done
@@ -669,6 +683,8 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
 
     for ( ;; )
     {
+        uint8_t cont = 0;
+
         if( year % 4 == 0 )
         {
             while( day > DaysInMonthLeapYear[month - 1] )
@@ -681,9 +697,15 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
                     month -= 12;
                     year++;
 
-                    // Year was changed, start from the scratch
-                    continue;
+                    cont = 1;
+                    break;
                 }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
             }
 
             // Calculations done
@@ -701,9 +723,15 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
                     month -= 12;
                     year++;
 
-                    // Year was changed, start from the scratch
-                    continue;
+                    cont = 1;
+                    break;
                 }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
             }
 
             // Calculations done

--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -259,7 +259,9 @@ void RtcSetTimeout( MsTime_t timeout )
 MsTime_t RtcGetAdjustedTimeoutValue( MsTime_t timeout )
 {
     if( timeout > McuWakeUpTime )
-    {   // we have waken up from a GPIO and we have lost "McuWakeUpTime" that we need to compensate on next event
+    {
+        // if we have woken up from a GPIO then we have lost "McuWakeUpTime"
+        // that we need to compensate on next event
         if( NonScheduledWakeUp == true )
         {
             NonScheduledWakeUp = false;
@@ -268,7 +270,8 @@ MsTime_t RtcGetAdjustedTimeoutValue( MsTime_t timeout )
     }
 
     if( timeout > McuWakeUpTime )
-    {   // we don't go in Low Power mode for delay below 50ms (needed for LEDs)
+    {
+        // we don't go into Low Power mode for a delay below 50ms (needed for LEDs)
         if( timeout < 50 ) // 50 ms
         {
             RtcTimerEventAllowsLowPower = false;
@@ -279,6 +282,11 @@ MsTime_t RtcGetAdjustedTimeoutValue( MsTime_t timeout )
             timeout -= McuWakeUpTime;
         }
     }
+    else
+    {
+        RtcTimerEventAllowsLowPower = false;
+    }
+
     return  timeout;
 }
 

--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -18,27 +18,34 @@ Maintainer: Miguel Luis and Gregory Cristian
 #include "rtc-board.h"
 
 /*!
- * RTC Time base in ms
+ * RTCCLK is 32768 Hz from LSE, or 37000 Hz from LSI
+ *
+ * It should be divided twice to get a 1 Hz clock:
+ *
+ * CK_SPRE = RTCCLK / ( PREDIV_A + 1 ) * ( PREDIV_S + 1 )
+ *
+ * LSE Example:
+ * 1 = 32768 / ( 16 * 2048 )
+ *
+ * LSI Example:
+ * 1 = 37000 / ( 37 * 1000 )
+ *
+ * PREDIV_A can be 1,2,3,..., or 127  (7-bit)
+ * PREDIV_S can be 0,1,2,..., or 8191 (13-bit)
+ *
+ * The PREDIV_S + 1 value also becomes the number of subseconds in a second,
+ * also note that subseconds are being counted from up to down
  */
-#define RTC_ALARM_TICK_PER_MS                       0x7FF           //  2047 > number of sub-second ticks per second
 
-/* sub-second number of bits */
-#define N_PREDIV_S                11
+/* Asynchronous prediv */
+#define PREDIV_A                  ( 16 - 1 )
 
-/* Synchronous prediv  */
-#define PREDIV_S                  ( ( 1 << N_PREDIV_S ) - 1 )
-
-/* Asynchronous prediv   */
-#define PREDIV_A                  ( 1 << ( 15 - N_PREDIV_S ) ) - 1
+/* Synchronous prediv */
+#define PREDIV_S                  ( 2048 - 1 )
 
 /* RTC Time base in us */
 #define USEC_NUMBER               1000000
-#define MSEC_NUMBER               ( USEC_NUMBER / 1000 )
-#define RTC_ALARM_TIME_BASE       ( USEC_NUMBER >> N_PREDIV_S )
-
-#define COMMON_FACTOR             3
-#define CONV_NUMER                ( MSEC_NUMBER >> COMMON_FACTOR )
-#define CONV_DENOM                ( 1 << ( N_PREDIV_S - COMMON_FACTOR ) )
+#define MSEC_NUMBER               1000
 
 /*!
  * Number of seconds in a minute
@@ -139,7 +146,7 @@ static void RtcComputeWakeUpTime( void );
 /*!
  * \brief Start the RTC Alarm (timeoutValue is in ms)
  */
-static void RtcStartWakeUpAlarm( uint32_t timeoutValue );
+static void RtcStartWakeUpAlarm( TimerTime_t timeoutValue );
 
 /*!
  * \brief Converts a TimerTime_t value into RtcCalendar_t value
@@ -200,40 +207,56 @@ void RtcInit( void )
         RtcHandle.Init.OutPut = RTC_OUTPUT_DISABLE;
         RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
         RtcHandle.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
-        HAL_RTC_Init( &RtcHandle );
+        if( HAL_RTC_Init( &RtcHandle ) != HAL_OK )
+        {
+            assert_param(FAIL);
+        }
 
-        // Set Date: Friday 1st of January 2000
-        rtcInit.CalendarDate.Year = 0;
-        rtcInit.CalendarDate.Month = RTC_MONTH_JANUARY;
-        rtcInit.CalendarDate.Date = 1;
-        rtcInit.CalendarDate.WeekDay = RTC_WEEKDAY_SATURDAY;
-        HAL_RTC_SetDate( &RtcHandle, &rtcInit.CalendarDate, RTC_FORMAT_BIN );
+        if( HAL_RTCEx_BKUPRead(&RtcHandle, RTC_BKP_DR0) != 0x32F2 )
+        {
+            // Set Date: Friday 1st of January 2000
+            rtcInit.CalendarDate.Year = 0;
+            rtcInit.CalendarDate.Month = RTC_MONTH_JANUARY;
+            rtcInit.CalendarDate.Date = 1;
+            rtcInit.CalendarDate.WeekDay = RTC_WEEKDAY_SATURDAY;
+            if( HAL_RTC_SetDate( &RtcHandle, &rtcInit.CalendarDate, RTC_FORMAT_BIN ) != HAL_OK )
+            {
+                assert_param(FAIL);
+            }
 
-        // Set Time: 00:00:00
-        rtcInit.CalendarTime.Hours = 0;
-        rtcInit.CalendarTime.Minutes = 0;
-        rtcInit.CalendarTime.Seconds = 0;
-        rtcInit.CalendarTime.SecondFraction = 0;
-        rtcInit.CalendarTime.TimeFormat = RTC_HOURFORMAT12_AM;
-        rtcInit.CalendarTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
-        rtcInit.CalendarTime.StoreOperation = RTC_STOREOPERATION_RESET;
-        HAL_RTC_SetTime( &RtcHandle, &rtcInit.CalendarTime, RTC_FORMAT_BIN );
+            // Set Time: 00:00:00
+            rtcInit.CalendarTime.Hours = 0;
+            rtcInit.CalendarTime.Minutes = 0;
+            rtcInit.CalendarTime.Seconds = 0;
+            rtcInit.CalendarTime.SecondFraction = 0;
+            rtcInit.CalendarTime.TimeFormat = RTC_HOURFORMAT12_AM;
+            rtcInit.CalendarTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+            rtcInit.CalendarTime.StoreOperation = RTC_STOREOPERATION_RESET;
+            if( HAL_RTC_SetTime( &RtcHandle, &rtcInit.CalendarTime, RTC_FORMAT_BIN ) != HAL_OK )
+            {
+                assert_param(FAIL);
+            }
+
+            HAL_RTCEx_BKUPWrite( &RtcHandle, RTC_BKP_DR0, 0x32F2 );
+        }
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)
         HAL_RTCEx_EnableBypassShadow( &RtcHandle );
 
+        // Enable the interrupt
         HAL_NVIC_SetPriority( RTC_IRQn, 1, 0 );
         HAL_NVIC_EnableIRQ( RTC_IRQn );
+
         RtcInitialized = true;
     }
 }
 
-void RtcSetTimeout( uint32_t timeout )
+void RtcSetTimeout( TimerTime_t timeout )
 {
     RtcStartWakeUpAlarm( RtcConvertMsToTick( timeout ) );
 }
 
-TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout )
+TimerTime_t RtcGetAdjustedTimeoutValue( TimerTime_t timeout )
 {
     if( timeout > McuWakeUpTime )
     {   // we have waken up from a GPIO and we have lost "McuWakeUpTime" that we need to compensate on next event
@@ -261,7 +284,8 @@ TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout )
 
 TimerTime_t RtcGetTimerValue( void )
 {
-    TimerTime_t retVal = 0;
+    TimerTime_t retVal;
+
     retVal = RtcConvertCalendarTickToTimerTime( NULL );
     RtcConvertTickToMs( retVal );
 
@@ -270,16 +294,16 @@ TimerTime_t RtcGetTimerValue( void )
 
 TimerTime_t RtcGetElapsedAlarmTime( void )
 {
-    TimerTime_t retVal = 0;
-    TimerTime_t currentTime = 0;
-    TimerTime_t contextTime = 0;
+    TimerTime_t retVal;
+    TimerTime_t currentTime;
+    TimerTime_t contextTime;
 
     currentTime = RtcConvertCalendarTickToTimerTime( NULL );
     contextTime = RtcConvertCalendarTickToTimerTime( &RtcCalendarContext );
 
     if( currentTime < contextTime )
     {
-        retVal = ( currentTime + ( 0xFFFFFFFF - contextTime ) );
+        retVal = ( currentTime + ( TIMERTIME_MAX - contextTime ) );
     }
     else
     {
@@ -295,7 +319,7 @@ TimerTime_t RtcComputeFutureEventTime( TimerTime_t futureEventInTime )
 
 TimerTime_t RtcComputeElapsedTime( TimerTime_t eventInTime )
 {
-    TimerTime_t elapsedTime = 0;
+    TimerTime_t elapsedTime;
 
     // Needed at boot, cannot compute with 0 or elapsed time will be equal to current time
     if( eventInTime == 0 )
@@ -309,7 +333,7 @@ TimerTime_t RtcComputeElapsedTime( TimerTime_t eventInTime )
 
     if( elapsedTime < eventInTime )
     { // roll over of the counter
-        return( elapsedTime + ( 0xFFFFFFFF - eventInTime ) );
+        return( elapsedTime + ( TIMERTIME_MAX - eventInTime ) );
     }
     else
     {
@@ -343,8 +367,18 @@ void RtcEnterLowPowerStopMode( void )
         // Enable the fast wake up from Ultra low power mode
         HAL_PWREx_EnableFastWakeUp( );
 
+        // SysTick interrupt would wake up the MCU for every tick
+        HAL_SuspendTick();
+
         // Enter Stop Mode
+#if defined(DEBUG)
+        HAL_PWR_EnterSTOPMode( PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI );
+#else
         HAL_PWR_EnterSTOPMode( PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI );
+#endif
+
+        // Resume the SysTick interrupt
+        HAL_ResumeTick( );
     }
 }
 
@@ -369,9 +403,9 @@ void RtcRecoverMcuStatus( void )
 
 static void RtcComputeWakeUpTime( void )
 {
-    uint32_t start = 0;
-    uint32_t stop = 0;
-    RTC_AlarmTypeDef  alarmRtc;
+    TimerTime_t start;
+    TimerTime_t stop;
+    RTC_AlarmTypeDef alarmRtc;
     RtcCalendar_t now;
 
     if( WakeUpTimeInitialized == false )
@@ -379,8 +413,15 @@ static void RtcComputeWakeUpTime( void )
         now = RtcGetCalendar( );
         HAL_RTC_GetAlarm( &RtcHandle, &alarmRtc, RTC_ALARM_A, RTC_FORMAT_BIN );
 
-        start = PREDIV_S - alarmRtc.AlarmTime.SubSeconds;
-        stop = PREDIV_S - now.CalendarTime.SubSeconds;
+        start = alarmRtc.AlarmTime.Hours    * 3600 * (PREDIV_S + 1);
+        start += alarmRtc.AlarmTime.Minutes * 60   * (PREDIV_S + 1);
+        start += alarmRtc.AlarmTime.Seconds * 1    * (PREDIV_S + 1);
+        start += PREDIV_S - alarmRtc.AlarmTime.SubSeconds;
+
+        stop = now.CalendarTime.Hours * 3600 * (PREDIV_S + 1);
+        stop += now.CalendarTime.Minutes * 60 * (PREDIV_S + 1);
+        stop += now.CalendarTime.Seconds * (PREDIV_S + 1);
+        stop += PREDIV_S - now.CalendarTime.SubSeconds;
 
         McuWakeUpTime = RtcConvertTickToMs( stop - start );
 
@@ -388,7 +429,7 @@ static void RtcComputeWakeUpTime( void )
     }
 }
 
-static void RtcStartWakeUpAlarm( uint32_t timeoutValue )
+static void RtcStartWakeUpAlarm( TimerTime_t timeoutValue )
 {
     RtcCalendar_t now;
     RtcCalendar_t alarmTimer;
@@ -407,7 +448,7 @@ static void RtcStartWakeUpAlarm( uint32_t timeoutValue )
     // Save the calendar into RtcCalendarContext to be able to calculate the elapsed time
     RtcCalendarContext = now;
 
-    // timeoutValue is in ms
+    // timeoutValue is in subseconds
     alarmTimer = RtcComputeTimerTimeToAlarmTick( timeoutValue, now );
 
     alarmStructure.Alarm = RTC_ALARM_A;
@@ -432,52 +473,50 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
 {
     RtcCalendar_t calendar = now;
 
-    TimerTime_t timeoutValue = 0;
-
-    uint16_t milliseconds = 0;
+    uint32_t subseconds = PREDIV_S - now.CalendarTime.SubSeconds;
     uint16_t seconds = now.CalendarTime.Seconds;
     uint16_t minutes = now.CalendarTime.Minutes;
     uint16_t hours = now.CalendarTime.Hours;
-    uint16_t days = now.CalendarDate.Date;
+    uint16_t day = now.CalendarDate.Date;
+    uint8_t month = now.CalendarDate.Month;
+    uint16_t year = now.CalendarDate.Year;
 
-    timeoutValue = timeCounter;
+    // Extract the subseconds part from the timeCounter
+    subseconds += timeCounter % ( PREDIV_S + 1 );
 
-    milliseconds = PREDIV_S - now.CalendarTime.SubSeconds;
-    milliseconds += ( timeoutValue & PREDIV_S);
+    // Convert timeout to whole seconds
+    timeCounter /= ( PREDIV_S + 1 );
 
-    /* convert timeout  to seconds */
-    timeoutValue >>= N_PREDIV_S;  /* convert timeout  in seconds */
-
-    // Convert milliseconds to RTC format and add to now
-    while( timeoutValue >= SecondsInDay )
+    // Calculate the days
+    while( timeCounter >= SecondsInDay )
     {
-        timeoutValue -= SecondsInDay;
-        days++;
+        timeCounter -= SecondsInDay;
+        day++;
     }
 
-    // Calculate hours
-    while( timeoutValue >= SecondsInHour )
+    // Calculate the hours
+    while( timeCounter >= SecondsInHour )
     {
-        timeoutValue -= SecondsInHour;
+        timeCounter -= SecondsInHour;
         hours++;
     }
 
-    // Calculate minutes
-    while( timeoutValue >= SecondsInMinute )
+    // Calculate the minutes
+    while( timeCounter >= SecondsInMinute )
     {
-        timeoutValue -= SecondsInMinute;
+        timeCounter -= SecondsInMinute;
         minutes++;
     }
 
-    // Calculate seconds
-    seconds += timeoutValue;
-
-    // Correct for modulo
-    while( milliseconds >= ( PREDIV_S + 1 ) )
+    // Calculate the seconds
+    seconds += timeCounter;
+    while( subseconds >= ( PREDIV_S + 1 ) )
     {
-        milliseconds -= ( PREDIV_S + 1 );
+        subseconds -= ( PREDIV_S + 1 );
         seconds++;
     }
+
+    // Convert the calculated seconds and subseconds into a calendar
 
     while( seconds >= SecondsInMinute )
     {
@@ -494,31 +533,60 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
     while( hours >= HoursInDay )
     {
         hours -= HoursInDay;
-        days++;
+        day++;
     }
 
-    if( ( now.CalendarDate.Year == 0 ) || ( now.CalendarDate.Year % 4 ) == 0 )
+    for ( ;; )
     {
-        if( days > DaysInMonthLeapYear[now.CalendarDate.Month - 1] )
+        if( year % 4 == 0 )
         {
-            days = days % DaysInMonthLeapYear[now.CalendarDate.Month - 1];
-            calendar.CalendarDate.Month++;
+            while( day > DaysInMonthLeapYear[month - 1] )
+            {
+                day -= DaysInMonthLeapYear[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    // Year was changed, start from the scratch
+                    continue;
+                }
+            }
+
+            // Calculations done
+            break;
         }
-    }
-    else
-    {
-        if( days > DaysInMonth[now.CalendarDate.Month - 1] )
+        else
         {
-            days = days % DaysInMonth[now.CalendarDate.Month - 1];
-            calendar.CalendarDate.Month++;
+            while( day > DaysInMonth[month - 1] )
+            {
+                day -= DaysInMonth[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    // Year was changed, start from the scratch
+                    continue;
+                }
+            }
+
+            // Calculations done
+            break;
         }
     }
 
-    calendar.CalendarTime.SubSeconds = PREDIV_S - milliseconds;
+    calendar.CalendarTime.SubSeconds = PREDIV_S - subseconds;
     calendar.CalendarTime.Seconds = seconds;
     calendar.CalendarTime.Minutes = minutes;
     calendar.CalendarTime.Hours = hours;
-    calendar.CalendarDate.Date = days;
+    calendar.CalendarDate.Date = day;
+    calendar.CalendarDate.Month = month;
+    calendar.CalendarDate.Year = year;
 
     return calendar;
 }
@@ -532,53 +600,50 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
 {
     RtcCalendar_t calendar = { { 0 }, { 0 } };
 
-    TimerTime_t timeoutValue = 0;
-
-    uint16_t milliseconds = 0;
+    uint32_t subseconds;
     uint16_t seconds = 0;
     uint16_t minutes = 0;
     uint16_t hours = 0;
-    uint16_t days = 0;
-    uint8_t months = 1; // Start at 1, month 0 does not exist
-    uint16_t years = 0;
+    uint16_t day = 0;
+    uint8_t month = 1; // Start at 1, month 0 does not exist
+    uint16_t year = 0;
 
-    timeoutValue = timeCounter;
+    // Extract the subseconds part from the timeCounter
+    subseconds = timeCounter % ( PREDIV_S + 1 );
 
-    milliseconds += ( timeoutValue & PREDIV_S);
+    // Convert timeout to whole seconds
+    timeCounter /= ( PREDIV_S + 1 );
 
-    /* convert timeout  to seconds */
-    timeoutValue >>= N_PREDIV_S; // convert timeout  in seconds
-
-    // Convert milliseconds to RTC format and add to now
-    while( timeoutValue >= SecondsInDay )
+    // Calculate the day
+    while( timeCounter >= SecondsInDay )
     {
-        timeoutValue -= SecondsInDay;
-        days++;
+        timeCounter -= SecondsInDay;
+        day++;
     }
 
-    // Calculate hours
-    while( timeoutValue >= SecondsInHour )
+    // Calculate the hours
+    while( timeCounter >= SecondsInHour )
     {
-        timeoutValue -= SecondsInHour;
+        timeCounter -= SecondsInHour;
         hours++;
     }
 
-    // Calculate minutes
-    while( timeoutValue >= SecondsInMinute )
+    // Calculate the minutes
+    while( timeCounter >= SecondsInMinute )
     {
-        timeoutValue -= SecondsInMinute;
+        timeCounter -= SecondsInMinute;
         minutes++;
     }
 
-    // Calculate seconds
-    seconds += timeoutValue;
-
-    // Correct for modulo
-    while( milliseconds >= ( PREDIV_S + 1 ) )
+    // Calculate the seconds
+    seconds += timeCounter;
+    while( subseconds >= ( PREDIV_S + 1 ) )
     {
-        milliseconds -= ( PREDIV_S + 1 );
+        subseconds -= ( PREDIV_S + 1 );
         seconds++;
     }
+
+    // Convert the calculated seconds and subseconds into a calendar
 
     while( seconds >= SecondsInMinute )
     {
@@ -595,22 +660,66 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
     while( hours >= HoursInDay )
     {
         hours -= HoursInDay;
-        days++;
+        day++;
     }
 
-    while( days > DaysInMonthLeapYear[months - 1] )
+    while( hours >= HoursInDay )
     {
-        days -= DaysInMonthLeapYear[months - 1];
-        months++;
+        hours -= HoursInDay;
+        day++;
     }
 
-    calendar.CalendarTime.SubSeconds = PREDIV_S - milliseconds;
+    for ( ;; )
+    {
+        if( year % 4 == 0 )
+        {
+            while( day > DaysInMonthLeapYear[month - 1] )
+            {
+                day -= DaysInMonthLeapYear[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    // Year was changed, start from the scratch
+                    continue;
+                }
+            }
+
+            // Calculations done
+            break;
+        }
+        else
+        {
+            while( day > DaysInMonth[month - 1] )
+            {
+                day -= DaysInMonth[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    // Year was changed, start from the scratch
+                    continue;
+                }
+            }
+
+            // Calculations done
+            break;
+        }
+    }
+
+    calendar.CalendarTime.SubSeconds = PREDIV_S - subseconds;
     calendar.CalendarTime.Seconds = seconds;
     calendar.CalendarTime.Minutes = minutes;
     calendar.CalendarTime.Hours = hours;
-    calendar.CalendarDate.Date = days;
-    calendar.CalendarDate.Month = months;
-    calendar.CalendarDate.Year = years; // on 32-bit, years will never go up
+    calendar.CalendarDate.Date = day;
+    calendar.CalendarDate.Month = month;
+    calendar.CalendarDate.Year = year;
 
     return calendar;
 }
@@ -619,7 +728,6 @@ static TimerTime_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar )
 {
     TimerTime_t timeCounter = 0;
     RtcCalendar_t now;
-    uint32_t timeCounterTemp = 0;
 
     // Passing a NULL pointer will compute from "now" else,
     // compute from the given calendar value
@@ -633,56 +741,64 @@ static TimerTime_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar )
     }
 
     // Years (calculation valid up to year 2099)
-    for( int16_t i = 0; i < now.CalendarDate.Year ; i++ )
+    for( uint8_t i = 0; i < now.CalendarDate.Year ; i++ )
     {
-        if( ( i == 0 ) || ( i % 4 ) == 0 )
+        if( i % 4 == 0 )
         {
-            timeCounterTemp += ( uint32_t )SecondsInLeapYear;
+            timeCounter += SecondsInLeapYear;
         }
         else
         {
-            timeCounterTemp += ( uint32_t )SecondsInYear;
+            timeCounter += SecondsInYear;
         }
     }
 
     // Months (calculation valid up to year 2099)*/
-    if( ( now.CalendarDate.Year == 0 ) || ( now.CalendarDate.Year % 4 ) == 0 )
+    if( now.CalendarDate.Year % 4 == 0 )
     {
         for( uint8_t i = 0; i < ( now.CalendarDate.Month - 1 ); i++ )
         {
-            timeCounterTemp += ( uint32_t )( DaysInMonthLeapYear[i] * SecondsInDay );
+            timeCounter += ( DaysInMonthLeapYear[i] * SecondsInDay );
         }
     }
     else
     {
         for( uint8_t i = 0;  i < ( now.CalendarDate.Month - 1 ); i++ )
         {
-            timeCounterTemp += ( uint32_t )( DaysInMonth[i] * SecondsInDay );
+            timeCounter += ( DaysInMonth[i] * SecondsInDay );
         }
     }
 
-    timeCounterTemp += ( uint32_t )( ( uint32_t )now.CalendarTime.Seconds +
-                     ( ( uint32_t )now.CalendarTime.Minutes * SecondsInMinute ) +
-                     ( ( uint32_t )now.CalendarTime.Hours * SecondsInHour ) +
-                     ( ( uint32_t )( now.CalendarDate.Date * SecondsInDay ) ) );
+    timeCounter += ( now.CalendarTime.Seconds +
+                     ( now.CalendarTime.Minutes * SecondsInMinute ) +
+                     ( now.CalendarTime.Hours * SecondsInHour ) +
+                     ( now.CalendarDate.Date * SecondsInDay ) );
 
-    timeCounter = ( timeCounterTemp << N_PREDIV_S ) + ( PREDIV_S - now.CalendarTime.SubSeconds);
+    timeCounter *= (PREDIV_S + 1);
+
+    timeCounter += PREDIV_S - now.CalendarTime.SubSeconds;
 
     return ( timeCounter );
 }
 
 TimerTime_t RtcConvertMsToTick( TimerTime_t timeoutValue )
 {
-    double retVal = 0;
-    retVal = round( ( ( double )timeoutValue * CONV_DENOM ) / CONV_NUMER );
+#if (PREDIV_S + 1 == MSEC_NUMBER)
+    return timeoutValue;
+#else
+    double retVal = round( ( double )( timeoutValue * ( PREDIV_S + 1 ) ) / MSEC_NUMBER );
     return( ( TimerTime_t )retVal );
+#endif
 }
 
 TimerTime_t RtcConvertTickToMs( TimerTime_t timeoutValue )
 {
-    double retVal = 0.0;
-    retVal = round( ( ( double )timeoutValue * CONV_NUMER ) / CONV_DENOM );
+#if (PREDIV_S + 1 == MSEC_NUMBER)
+    return timeoutValue;
+#else
+    double retVal = round( ( double ) ( timeoutValue * MSEC_NUMBER ) / ( PREDIV_S + 1 ) );
     return( ( TimerTime_t )retVal );
+#endif
 }
 
 static RtcCalendar_t RtcGetCalendar( void )

--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -30,8 +30,8 @@ Maintainer: Miguel Luis and Gregory Cristian
  * LSI Example:
  * 1 = 37000 / ( 37 * 1000 )
  *
- * PREDIV_A can be 1,2,3,..., or 127  (7-bit)
- * PREDIV_S can be 0,1,2,..., or 8191 (13-bit)
+ * PREDIV_A can be 1,2,3,..., or 127   (7-bit),  defaults to 127
+ * PREDIV_S can be 0,1,2,..., or 32767 (15-bit), defaults to 255
  *
  * The PREDIV_S + 1 value also becomes the number of subseconds in a second,
  * also note that subseconds are being counted from up to down

--- a/src/boards/MoteII/rtc-board.h
+++ b/src/boards/MoteII/rtc-board.h
@@ -24,6 +24,11 @@ typedef uint64_t TimerTime_t;
 #define TIMERTIME_MAX (0xFFFFFFFFFFFFFFFFULL)
 #endif
 
+#ifndef MsTime_t
+typedef TimerTime_t MsTime_t;
+#define MSTIME_MAX TIMERTIME_MAX
+#endif
+
 /*!
  * \brief Initializes the RTC timer
  *
@@ -38,7 +43,7 @@ void RtcInit( void );
  *
  * \param[IN] timeout Duration of the Timer
  */
-void RtcSetTimeout( TimerTime_t timeout );
+void RtcSetTimeout( MsTime_t timeout );
 
 /*!
  * \brief Adjust the value of the timeout to handle wakeup time from Alarm and GPIO irq
@@ -46,21 +51,21 @@ void RtcSetTimeout( TimerTime_t timeout );
  * \param[IN] timeout Duration of the Timer without compensation for wakeup time
  * \retval new value for the Timeout with compensations
  */
-TimerTime_t RtcGetAdjustedTimeoutValue( TimerTime_t timeout );
+MsTime_t RtcGetAdjustedTimeoutValue( MsTime_t timeout );
 
 /*!
  * \brief Get the RTC timer value
  *
  * \retval RTC Timer value
  */
-TimerTime_t RtcGetTimerValue( void );
+MsTime_t RtcGetTimerValue( void );
 
 /*!
  * \brief Get the RTC timer elapsed time since the last Alarm was set
  *
  * \retval RTC Elapsed time since the last alarm
  */
-TimerTime_t RtcGetElapsedAlarmTime( void );
+MsTime_t RtcGetElapsedAlarmTime( void );
 
 /*!
  * \brief Compute the timeout time of a future event in time
@@ -68,7 +73,7 @@ TimerTime_t RtcGetElapsedAlarmTime( void );
  * \param[IN] futureEventInTime Value in time
  * \retval time Time between now and the futureEventInTime
  */
-TimerTime_t RtcComputeFutureEventTime( TimerTime_t futureEventInTime );
+MsTime_t RtcComputeFutureEventTime( MsTime_t futureEventInTime );
 
 /*!
  * \brief Compute the elapsed time since a fix event in time
@@ -76,7 +81,7 @@ TimerTime_t RtcComputeFutureEventTime( TimerTime_t futureEventInTime );
  * \param[IN] eventInTime Value in time
  * \retval elapsed Time since the eventInTime
  */
-TimerTime_t RtcComputeElapsedTime( TimerTime_t eventInTime );
+MsTime_t RtcComputeElapsedTime( MsTime_t eventInTime );
 
 /*!
  * \brief This function blocks the MCU from going into Low Power mode

--- a/src/boards/MoteII/rtc-board.h
+++ b/src/boards/MoteII/rtc-board.h
@@ -17,10 +17,11 @@ Maintainer: Miguel Luis and Gregory Cristian
 #define __RTC_BOARD_H__
 
 /*!
- * \brief Timer time variable definition
+ * \brief Timer time variable definition (time in RTC subseconds)
  */
 #ifndef TimerTime_t
-typedef uint32_t TimerTime_t;
+typedef uint64_t TimerTime_t;
+#define TIMERTIME_MAX (0xFFFFFFFFFFFFFFFFULL)
 #endif
 
 /*!
@@ -37,7 +38,7 @@ void RtcInit( void );
  *
  * \param[IN] timeout Duration of the Timer
  */
-void RtcSetTimeout( uint32_t timeout );
+void RtcSetTimeout( TimerTime_t timeout );
 
 /*!
  * \brief Adjust the value of the timeout to handle wakeup time from Alarm and GPIO irq
@@ -45,7 +46,7 @@ void RtcSetTimeout( uint32_t timeout );
  * \param[IN] timeout Duration of the Timer without compensation for wakeup time
  * \retval new value for the Timeout with compensations
  */
-TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout );
+TimerTime_t RtcGetAdjustedTimeoutValue( TimerTime_t timeout );
 
 /*!
  * \brief Get the RTC timer value

--- a/src/system/timer.c
+++ b/src/system/timer.c
@@ -36,7 +36,7 @@ static TimerEvent_t *TimerListHead = NULL;
  * \param [IN]  obj Timer object to be become the new head
  * \param [IN]  remainingTime Remaining time of the previous head to be replaced
  */
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime );
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
 
 /*!
  * \brief Adds a timer to the list.
@@ -47,7 +47,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
  * \param [IN]  obj Timer object to be added to the list
  * \param [IN]  remainingTime Remaining time of the running head after which the object may be added
  */
-static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime );
+static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
 
 /*!
  * \brief Sets a timeout with the duration "timestamp"
@@ -82,8 +82,8 @@ void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 
 void TimerStart( TimerEvent_t *obj )
 {
-    uint32_t elapsedTime = 0;
-    uint32_t remainingTime = 0;
+    TimerTime_t elapsedTime = 0;
+    TimerTime_t remainingTime = 0;
 
     BoardDisableIrq( );
 
@@ -128,10 +128,10 @@ void TimerStart( TimerEvent_t *obj )
     BoardEnableIrq( );
 }
 
-static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime )
+static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
 {
-    uint32_t aggregatedTimestamp = 0;      // hold the sum of timestamps
-    uint32_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
+    TimerTime_t aggregatedTimestamp = 0;      // hold the sum of timestamps
+    TimerTime_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead->Next;
@@ -182,7 +182,7 @@ static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime )
     }
 }
 
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
 {
     TimerEvent_t* cur = TimerListHead;
 
@@ -200,7 +200,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
 
 void TimerIrqHandler( void )
 {
-    uint32_t elapsedTime = 0;
+    TimerTime_t elapsedTime = 0;
 
     // Early out when TimerListHead is null to prevent null pointer
     if ( TimerListHead == NULL )
@@ -247,8 +247,8 @@ void TimerStop( TimerEvent_t *obj )
 {
     BoardDisableIrq( );
 
-    uint32_t elapsedTime = 0;
-    uint32_t remainingTime = 0;
+    TimerTime_t elapsedTime = 0;
+    TimerTime_t remainingTime = 0;
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead;
@@ -351,7 +351,7 @@ void TimerReset( TimerEvent_t *obj )
     TimerStart( obj );
 }
 
-void TimerSetValue( TimerEvent_t *obj, uint32_t value )
+void TimerSetValue( TimerEvent_t *obj, TimerTime_t value )
 {
     TimerStop( obj );
     obj->Timestamp = value;

--- a/src/system/timer.c
+++ b/src/system/timer.c
@@ -36,7 +36,7 @@ static TimerEvent_t *TimerListHead = NULL;
  * \param [IN]  obj Timer object to be become the new head
  * \param [IN]  remainingTime Remaining time of the previous head to be replaced
  */
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, MsTime_t remainingTime );
 
 /*!
  * \brief Adds a timer to the list.
@@ -47,7 +47,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTim
  * \param [IN]  obj Timer object to be added to the list
  * \param [IN]  remainingTime Remaining time of the running head after which the object may be added
  */
-static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
+static void TimerInsertTimer( TimerEvent_t *obj, MsTime_t remainingTime );
 
 /*!
  * \brief Sets a timeout with the duration "timestamp"
@@ -69,7 +69,7 @@ static bool TimerExists( TimerEvent_t *obj );
  *
  * \retval value current timer value
  */
-TimerTime_t TimerGetValue( void );
+static MsTime_t TimerGetValue( void );
 
 void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 {
@@ -82,8 +82,8 @@ void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 
 void TimerStart( TimerEvent_t *obj )
 {
-    TimerTime_t elapsedTime = 0;
-    TimerTime_t remainingTime = 0;
+    MsTime_t elapsedTime = 0;
+    MsTime_t remainingTime = 0;
 
     BoardDisableIrq( );
 
@@ -128,10 +128,10 @@ void TimerStart( TimerEvent_t *obj )
     BoardEnableIrq( );
 }
 
-static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
+static void TimerInsertTimer( TimerEvent_t *obj, MsTime_t remainingTime )
 {
-    TimerTime_t aggregatedTimestamp = 0;      // hold the sum of timestamps
-    TimerTime_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
+    MsTime_t aggregatedTimestamp = 0;      // hold the sum of timestamps
+    MsTime_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead->Next;
@@ -182,7 +182,7 @@ static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
     }
 }
 
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, MsTime_t remainingTime )
 {
     TimerEvent_t* cur = TimerListHead;
 
@@ -200,7 +200,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTim
 
 void TimerIrqHandler( void )
 {
-    TimerTime_t elapsedTime = 0;
+    MsTime_t elapsedTime = 0;
 
     // Early out when TimerListHead is null to prevent null pointer
     if ( TimerListHead == NULL )
@@ -247,8 +247,8 @@ void TimerStop( TimerEvent_t *obj )
 {
     BoardDisableIrq( );
 
-    TimerTime_t elapsedTime = 0;
-    TimerTime_t remainingTime = 0;
+    MsTime_t elapsedTime = 0;
+    MsTime_t remainingTime = 0;
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead;
@@ -351,29 +351,29 @@ void TimerReset( TimerEvent_t *obj )
     TimerStart( obj );
 }
 
-void TimerSetValue( TimerEvent_t *obj, TimerTime_t value )
+void TimerSetValue( TimerEvent_t *obj, MsTime_t value )
 {
     TimerStop( obj );
     obj->Timestamp = value;
     obj->ReloadValue = value;
 }
 
-TimerTime_t TimerGetValue( void )
+static MsTime_t TimerGetValue( void )
 {
     return RtcGetElapsedAlarmTime( );
 }
 
-TimerTime_t TimerGetCurrentTime( void )
+MsTime_t TimerGetCurrentTime( void )
 {
     return RtcGetTimerValue( );
 }
 
-TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime )
+MsTime_t TimerGetElapsedTime( MsTime_t savedTime )
 {
     return RtcComputeElapsedTime( savedTime );
 }
 
-TimerTime_t TimerGetFutureTime( TimerTime_t eventInFuture )
+MsTime_t TimerGetFutureTime( MsTime_t eventInFuture )
 {
     return RtcComputeFutureEventTime( eventInFuture );
 }

--- a/src/system/timer.h
+++ b/src/system/timer.h
@@ -23,13 +23,18 @@ typedef uint64_t TimerTime_t;
 #define TIMERTIME_MAX (0xFFFFFFFFFFFFFFFFULL)
 #endif
 
+#ifndef MsTime_t
+typedef TimerTime_t MsTime_t;
+#define MSTIME_MAX TIMERTIME_MAX
+#endif
+
 /*!
  * \brief Timer object description
  */
 typedef struct TimerEvent_s
 {
-    TimerTime_t Timestamp;      //! Current timer value
-    TimerTime_t ReloadValue;    //! Timer delay value
+    MsTime_t Timestamp;         //! Current timer value
+    MsTime_t ReloadValue;       //! Timer delay value
     bool IsRunning;             //! Is the timer currently running
     void ( *Callback )( void ); //! Timer IRQ callback function
     struct TimerEvent_s *Next;  //! Pointer to the next Timer object.
@@ -78,14 +83,14 @@ void TimerReset( TimerEvent_t *obj );
  * \param [IN] obj   Structure containing the timer object parameters
  * \param [IN] value New timer timeout value
  */
-void TimerSetValue( TimerEvent_t *obj, TimerTime_t value );
+void TimerSetValue( TimerEvent_t *obj, MsTime_t value );
 
 /*!
  * \brief Read the current time
  *
  * \retval time returns current time
  */
-TimerTime_t TimerGetCurrentTime( void );
+MsTime_t TimerGetCurrentTime( void );
 
 /*!
  * \brief Return the Time elapsed since a fix moment in Time
@@ -93,7 +98,7 @@ TimerTime_t TimerGetCurrentTime( void );
  * \param [IN] savedTime    fix moment in Time
  * \retval time             returns elapsed time
  */
-TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime );
+MsTime_t TimerGetElapsedTime( MsTime_t savedTime );
 
 /*!
  * \brief Return the Time elapsed since a fix moment in Time
@@ -101,7 +106,7 @@ TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime );
  * \param [IN] eventInFuture    fix moment in the future
  * \retval time             returns difference between now and future event
  */
-TimerTime_t TimerGetFutureTime( TimerTime_t eventInFuture );
+MsTime_t TimerGetFutureTime( MsTime_t eventInFuture );
 
 /*!
  * \brief Manages the entry into ARM cortex deep-sleep mode

--- a/src/system/timer.h
+++ b/src/system/timer.h
@@ -16,23 +16,24 @@ Maintainer: Miguel Luis and Gregory Cristian
 #define __TIMER_H__
 
 /*!
+ * \brief Timer time variable definition
+ */
+#ifndef TimerTime_t
+typedef uint64_t TimerTime_t;
+#define TIMERTIME_MAX (0xFFFFFFFFFFFFFFFFULL)
+#endif
+
+/*!
  * \brief Timer object description
  */
 typedef struct TimerEvent_s
 {
-    uint32_t Timestamp;         //! Current timer value
-    uint32_t ReloadValue;       //! Timer delay value
+    TimerTime_t Timestamp;      //! Current timer value
+    TimerTime_t ReloadValue;    //! Timer delay value
     bool IsRunning;             //! Is the timer currently running
     void ( *Callback )( void ); //! Timer IRQ callback function
     struct TimerEvent_s *Next;  //! Pointer to the next Timer object.
 }TimerEvent_t;
-
-/*!
- * \brief Timer time variable definition
- */
-#ifndef TimerTime_t
-typedef uint32_t TimerTime_t;
-#endif
 
 /*!
  * \brief Initializes the timer object
@@ -77,7 +78,7 @@ void TimerReset( TimerEvent_t *obj );
  * \param [IN] obj   Structure containing the timer object parameters
  * \param [IN] value New timer timeout value
  */
-void TimerSetValue( TimerEvent_t *obj, uint32_t value );
+void TimerSetValue( TimerEvent_t *obj, TimerTime_t value );
 
 /*!
  * \brief Read the current time


### PR DESCRIPTION
In this branch we have refactored the Mote II board's RTC module and the main Timer module:

* fix the bug of the subseconds-based 32-bit TimerTime_t being too small to hold times longer than ~24 days
* refactor the rtc-board.c module's code, fix some minor bugs in the process
* introduce a new time type (MsTime_t) to differentiate between subseconds-based and milliseconds-based times
* minor additions unrelated to RTC

The changes were not thoroughly tested, please review the commits and feel free to comment.

Thank you.