### PR TITLE
Au915

### DIFF
--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -300,14 +300,14 @@ void RegionAU915InitDefaults( InitType_t type )
             for( uint8_t i = 0; i < AU915_MAX_NB_CHANNELS - 8; i++ )
             {
                 Channels[i].Frequency = 915.2e6 + i * 200e3;
-                Channels[i].DrRange.Value = ( DR_3 << 4 ) | DR_0;
+                Channels[i].DrRange.Value = ( DR_5 << 4 ) | DR_0;
                 Channels[i].Band = 0;
             }
             // 500 kHz channels
             for( uint8_t i = AU915_MAX_NB_CHANNELS - 8; i < AU915_MAX_NB_CHANNELS; i++ )
             {
                 Channels[i].Frequency = 915.9e6 + ( i - ( AU915_MAX_NB_CHANNELS - 8 ) ) * 1.6e6;
-                Channels[i].DrRange.Value = ( DR_4 << 4 ) | DR_4;
+                Channels[i].DrRange.Value = ( DR_6 << 4 ) | DR_6;
                 Channels[i].Band = 0;
             }
 
@@ -621,7 +621,7 @@ uint8_t RegionAU915LinkAdrReq( LinkAdrReqParams_t* linkAdrReq, int8_t* drOut, in
     }
 
     // FCC 15.247 paragraph F mandates to hop on at least 2 125 kHz channels
-    if( ( linkAdrParams.Datarate < DR_4 ) && ( RegionCommonCountChannels( channelsMask, 0, 4 ) < 2 ) )
+    if( ( linkAdrParams.Datarate < DR_6 ) && ( RegionCommonCountChannels( channelsMask, 0, 4 ) < 2 ) )
     {
         status &= 0xFE; // Channel mask KO
     }
@@ -693,7 +693,7 @@ uint8_t RegionAU915RxParamSetupReq( RxParamSetupReqParams_t* rxParamSetupReq )
     {
         status &= 0xFD; // Datarate KO
     }
-    if( ( RegionCommonValueInRange( rxParamSetupReq->Datarate, DR_5, DR_7 ) == true ) ||
+    if( ( rxParamSetupReq->Datarate == DR_7 ) ||
         ( rxParamSetupReq->Datarate > DR_13 ) )
     {
         status &= 0xFD; // Datarate KO
@@ -733,7 +733,7 @@ int8_t RegionAU915AlternateDr( AlternateDrParams_t* alternateDr )
 
     if( ( alternateDr->NbTrials & 0x01 ) == 0x01 )
     {
-        datarate = DR_4;
+        datarate = DR_6;
     }
     else
     {
@@ -773,7 +773,7 @@ bool RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_t* channel,
         RegionCommonChanMaskCopy( ChannelsMaskRemaining, ChannelsMask, 4  );
     }
     // Check other channels
-    if( nextChanParams->Datarate >= DR_4 )
+    if( nextChanParams->Datarate >= DR_6 )
     {
         if( ( ChannelsMaskRemaining[4] & 0x00FF ) == 0 )
         {

--- a/src/mac/region/RegionAU915.h
+++ b/src/mac/region/RegionAU915.h
@@ -73,7 +73,7 @@
 /*!
  * Maximal Rx1 receive datarate offset
  */
-#define AU915_MAX_RX1_DR_OFFSET                     3
+#define AU915_MAX_RX1_DR_OFFSET                     6
 
 /*!
  * Default Rx1 receive datarate offset
@@ -209,13 +209,15 @@ static const uint32_t BandwidthsAU915[] = { 125e3, 125e3, 125e3, 125e3, 125e3, 1
 /*!
  * Up/Down link data rates offset definition
  */
-static const int8_t DatarateOffsetsAU915[5][4] =
+static const int8_t DatarateOffsetsAU915[7][6] =
 {
-    { DR_10, DR_9 , DR_8 , DR_8  }, // DR_0
-    { DR_11, DR_10, DR_9 , DR_8  }, // DR_1
-    { DR_12, DR_11, DR_10, DR_9  }, // DR_2
-    { DR_13, DR_12, DR_11, DR_10 }, // DR_3
-    { DR_13, DR_13, DR_12, DR_11 }, // DR_4
+    { DR_8 , DR_8 , DR_8 , DR_8 , DR_8 , DR_8  }, // DR_0
+    { DR_9 , DR_8 , DR_8 , DR_8 , DR_8 , DR_8  }, // DR_1
+    { DR_10, DR_9 , DR_8 , DR_8 , DR_8 , DR_8  }, // DR_2
+    { DR_11, DR_10, DR_9 , DR_8 , DR_8 , DR_8  }, // DR_3
+    { DR_12, DR_11, DR_10, DR_9 , DR_8 , DR_8  }, // DR_4
+    { DR_13, DR_12, DR_11, DR_10, DR_9 , DR_8  }, // DR_5
+    { DR_13, DR_13, DR_12, DR_11, DR_10, DR_9  }, // DR_6
 };
 
 /*!


### PR DESCRIPTION
Values have been modified for Region AU915 to correspond to regional parameter 1.0.2rB in this commit [https://github.com/Lora-net/LoRaMac-node/commit/c766d0635dd9410e3b39efd1aa61afe762b5eebc](url) but Datarates have not been modified accordingly.