### PR TITLE
update AS923 Maximum payload size

### DIFF
--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -214,7 +214,7 @@ PhyParam_t RegionAS923GetPhyParam( GetPhyParams_t* getPhy )
             }
             else
             {
-                phyParam.Value = MaxPayloadOfDatarateDwell1UpAS923[getPhy->Datarate];
+                phyParam.Value = MaxPayloadOfDatarateDwell1AS923[getPhy->Datarate];
             }
             break;
         }
@@ -226,7 +226,7 @@ PhyParam_t RegionAS923GetPhyParam( GetPhyParams_t* getPhy )
             }
             else
             {
-                phyParam.Value = MaxPayloadOfDatarateDwell1UpAS923[getPhy->Datarate];
+                phyParam.Value = MaxPayloadOfDatarateDwell1AS923[getPhy->Datarate];
             }
             break;
         }

--- a/src/mac/region/RegionAS923.h
+++ b/src/mac/region/RegionAS923.h
@@ -262,15 +262,9 @@ static const uint8_t MaxPayloadOfDatarateRepeaterDwell0AS923[] = { 59, 59, 59, 1
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with and without repeater.
- * The table proides repeater support. The table is only valid for uplinks.
+ * The table is valid for the dwell time configuration of 1 for uplinks and downlinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell1UpAS923[] = { 0, 0, 19, 61, 133, 250, 250, 250 };
-
-/*!
- * Maximum payload with respect to the datarate index. Can operate with and without repeater.
- * The table proides repeater support. The table is only valid for downlinks.
- */
-static const uint8_t MaxPayloadOfDatarateDwell1DownAS923[] = { 0, 0, 19, 61, 133, 250, 250, 250 };
+static const uint8_t MaxPayloadOfDatarateDwell1AS923[] = { 0, 0, 19, 61, 133, 250, 250, 250 };
 
 /*!
  * Effective datarate offsets for receive window 1.

--- a/src/mac/region/RegionAS923.h
+++ b/src/mac/region/RegionAS923.h
@@ -252,26 +252,25 @@ static const uint32_t BandwidthsAS923[] = { 125000, 125000, 125000, 125000, 1250
  * Maximum payload with respect to the datarate index. Cannot operate with repeater.
  * The table is valid for the dwell time configuration of 0 for uplinks and downlinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell0AS923[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateDwell0AS923[] = { 59, 59, 59, 123, 250, 250, 250, 250 };
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with repeater.
- * The table is valid for the dwell time configuration of 0 for uplinks and downlinks. The table provides
- * repeater support.
+ * The table is valid for the dwell time configuration of 0 for uplinks and downlinks.
  */
-static const uint8_t MaxPayloadOfDatarateRepeaterDwell0AS923[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+static const uint8_t MaxPayloadOfDatarateRepeaterDwell0AS923[] = { 59, 59, 59, 123, 230, 230, 230, 230 };
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with and without repeater.
  * The table proides repeater support. The table is only valid for uplinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell1UpAS923[] = { 0, 0, 11, 53, 125, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateDwell1UpAS923[] = { 0, 0, 19, 61, 133, 250, 250, 250 };
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with and without repeater.
  * The table proides repeater support. The table is only valid for downlinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell1DownAS923[] = { 0, 0, 11, 53, 126, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateDwell1DownAS923[] = { 0, 0, 19, 61, 133, 250, 250, 250 };
 
 /*!
  * Effective datarate offsets for receive window 1.


### PR DESCRIPTION
as hinted by @catsup in https://github.com/Lora-net/LoRaMac-node/issues/314
acording to LoRaWAN 1.0.2 Regional Parameters Revision B

also MaxPayloadOfDatarateDwell1UpAS923 and MaxPayloadOfDatarateDwell1DownAS923 can be merged