### PR TITLE
Mote II RTC & Timer: Make TimerTime_t 64-bits

### DIFF
--- a/src/boards/MoteII/rtc-board.c
+++ b/src/boards/MoteII/rtc-board.c
@@ -18,27 +18,46 @@ Maintainer: Miguel Luis and Gregory Cristian
 #include "rtc-board.h"
 
 /*!
- * RTC Time base in ms
+ * \brief TimerTick_t type definition
+ *
+ * \remark TimerTick_t is used for variables counting in timer ticks
+ * which normally have a sub-millisecond resolution
+ *
  */
-#define RTC_ALARM_TICK_PER_MS                       0x7FF           //  2047 > number of sub-second ticks per second
+#ifndef TimerTick_t
+typedef uint64_t TimerTick_t;
+#define TIMERTICK_MAX ((TimerTick_t) UINT64_MAX))
+#endif
 
-/* sub-second number of bits */
-#define N_PREDIV_S                11
+/*!
+ * RTCCLK is 32768 Hz from LSE, or 37000 Hz from LSI
+ *
+ * It should be divided twice to get a 1 Hz clock:
+ *
+ * CK_SPRE = RTCCLK / ( PREDIV_A + 1 ) * ( PREDIV_S + 1 )
+ *
+ * LSE Example:
+ * 1 = 32768 / ( 16 * 2048 )
+ *
+ * LSI Example:
+ * 1 = 37000 / ( 37 * 1000 )
+ *
+ * PREDIV_A can be 1,2,3,..., or 127   (7-bit),  defaults to 127
+ * PREDIV_S can be 0,1,2,..., or 32767 (15-bit), defaults to 255
+ *
+ * The PREDIV_S + 1 value also becomes the number of subseconds in a second,
+ * also note that subseconds are being counted from up to down
+ */
 
-/* Synchronous prediv  */
-#define PREDIV_S                  ( ( 1 << N_PREDIV_S ) - 1 )
+/* Asynchronous prediv */
+#define PREDIV_A                  ( 16 - 1 )
 
-/* Asynchronous prediv   */
-#define PREDIV_A                  ( 1 << ( 15 - N_PREDIV_S ) ) - 1
+/* Synchronous prediv */
+#define PREDIV_S                  ( 2048 - 1 )
 
 /* RTC Time base in us */
 #define USEC_NUMBER               1000000
-#define MSEC_NUMBER               ( USEC_NUMBER / 1000 )
-#define RTC_ALARM_TIME_BASE       ( USEC_NUMBER >> N_PREDIV_S )
-
-#define COMMON_FACTOR             3
-#define CONV_NUMER                ( MSEC_NUMBER >> COMMON_FACTOR )
-#define CONV_DENOM                ( 1 << ( N_PREDIV_S - COMMON_FACTOR ) )
+#define MSEC_NUMBER               1000
 
 /*!
  * Number of seconds in a minute
@@ -129,7 +148,7 @@ static bool WakeUpTimeInitialized = false;
 /*!
  * \brief Hold the Wake-up time duration in ms
  */
-volatile uint32_t McuWakeUpTime = 0;
+volatile TimerTime_t McuWakeUpTime = 0;
 
 /*!
  * \brief RTC wakeup time computation
@@ -139,10 +158,10 @@ static void RtcComputeWakeUpTime( void );
 /*!
  * \brief Start the RTC Alarm (timeoutValue is in ms)
  */
-static void RtcStartWakeUpAlarm( uint32_t timeoutValue );
+static void RtcStartWakeUpAlarm( TimerTick_t timeoutValue );
 
 /*!
- * \brief Converts a TimerTime_t value into RtcCalendar_t value
+ * \brief Converts a TimerTick_t value into RtcCalendar_t value
  *
  * \param[IN] timeCounter Value to convert to RTC calendar
  * \retval rtcCalendar New RTC calendar value
@@ -150,32 +169,32 @@ static void RtcStartWakeUpAlarm( uint32_t timeoutValue );
 //
 // REMARK: Removed function static attribute in order to suppress
 //         "#177-D function was declared but never referenced" warning.
-// static RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
+// static RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTick_t timeCounter )
 //
-RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter );
+RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTick_t timeCounter );
 
 /*!
- * \brief Converts a RtcCalendar_t value into TimerTime_t value
+ * \brief Converts a RtcCalendar_t value into TimerTick_t value
  *
  * \param[IN/OUT] calendar Calendar value to be converted
  *                         [NULL: compute from "now",
  *                          Others: compute from given calendar value]
- * \retval timerTime New TimerTime_t value
+ * \retval timerTime New TimerTick_t value
  */
-static TimerTime_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar );
+static TimerTick_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar );
 
-static TimerTime_t RtcConvertMsToTick( TimerTime_t timeoutValue );
+static TimerTick_t RtcConvertMsToTick( TimerTime_t timeoutValue );
 
-static TimerTime_t RtcConvertTickToMs( TimerTime_t timeoutValue );
+static TimerTime_t RtcConvertTickToMs( TimerTick_t timeoutValue );
 
 /*!
- * \brief Converts a TimerTime_t value into a value for the RTC Alarm
+ * \brief Converts a TimerTick_t value into a value for the RTC Alarm
  *
  * \param[IN] timeCounter Value in ms to convert into a calendar alarm date
  * \param[IN] now Current RTC calendar context
  * \retval rtcCalendar Value for the RTC Alarm
  */
-static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, RtcCalendar_t now );
+static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTick_t timeCounter, RtcCalendar_t now );
 
 /*!
  * \brief Returns the internal RTC Calendar and check for RTC overflow
@@ -228,15 +247,17 @@ void RtcInit( void )
     }
 }
 
-void RtcSetTimeout( uint32_t timeout )
+void RtcSetTimeout( TimerTime_t timeout )
 {
     RtcStartWakeUpAlarm( RtcConvertMsToTick( timeout ) );
 }
 
-TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout )
+TimerTime_t RtcGetAdjustedTimeoutValue( TimerTime_t timeout )
 {
     if( timeout > McuWakeUpTime )
-    {   // we have waken up from a GPIO and we have lost "McuWakeUpTime" that we need to compensate on next event
+    {
+        // if we have woken up from a GPIO then we have lost "McuWakeUpTime"
+        // that we need to compensate on next event
         if( NonScheduledWakeUp == true )
         {
             NonScheduledWakeUp = false;
@@ -245,7 +266,8 @@ TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout )
     }
 
     if( timeout > McuWakeUpTime )
-    {   // we don't go in Low Power mode for delay below 50ms (needed for LEDs)
+    {
+        // we don't go into Low Power mode for a delay below 50ms (needed for LEDs)
         if( timeout < 50 ) // 50 ms
         {
             RtcTimerEventAllowsLowPower = false;
@@ -256,35 +278,41 @@ TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout )
             timeout -= McuWakeUpTime;
         }
     }
+    else
+    {
+        RtcTimerEventAllowsLowPower = false;
+    }
+
     return  timeout;
 }
 
 TimerTime_t RtcGetTimerValue( void )
 {
-    TimerTime_t retVal = 0;
+    TimerTick_t retVal;
+
     retVal = RtcConvertCalendarTickToTimerTime( NULL );
-    RtcConvertTickToMs( retVal );
 
     return( RtcConvertTickToMs( retVal ) );
 }
 
 TimerTime_t RtcGetElapsedAlarmTime( void )
 {
-    TimerTime_t retVal = 0;
-    TimerTime_t currentTime = 0;
-    TimerTime_t contextTime = 0;
+    TimerTick_t retVal = 0;
+    TimerTick_t currentTime = 0;
+    TimerTick_t contextTime = 0;
 
     currentTime = RtcConvertCalendarTickToTimerTime( NULL );
     contextTime = RtcConvertCalendarTickToTimerTime( &RtcCalendarContext );
 
     if( currentTime < contextTime )
     {
-        retVal = ( currentTime + ( 0xFFFFFFFF - contextTime ) );
+        retVal = ( currentTime + ( TIMERTIME_MAX - contextTime ) );
     }
     else
     {
         retVal = ( currentTime - contextTime );
     }
+
     return( RtcConvertTickToMs( retVal ) );
 }
 
@@ -295,7 +323,7 @@ TimerTime_t RtcComputeFutureEventTime( TimerTime_t futureEventInTime )
 
 TimerTime_t RtcComputeElapsedTime( TimerTime_t eventInTime )
 {
-    TimerTime_t elapsedTime = 0;
+    TimerTime_t elapsedTime;
 
     // Needed at boot, cannot compute with 0 or elapsed time will be equal to current time
     if( eventInTime == 0 )
@@ -303,13 +331,11 @@ TimerTime_t RtcComputeElapsedTime( TimerTime_t eventInTime )
         return 0;
     }
 
-    elapsedTime = RtcConvertCalendarTickToTimerTime( NULL );
-
-    elapsedTime = RtcConvertTickToMs( elapsedTime );
+    elapsedTime = RtcConvertTickToMs( RtcConvertCalendarTickToTimerTime( NULL ) );
 
     if( elapsedTime < eventInTime )
     { // roll over of the counter
-        return( elapsedTime + ( 0xFFFFFFFF - eventInTime ) );
+        return( elapsedTime + ( TIMERTIME_MAX - eventInTime ) );
     }
     else
     {
@@ -369,9 +395,9 @@ void RtcRecoverMcuStatus( void )
 
 static void RtcComputeWakeUpTime( void )
 {
-    uint32_t start = 0;
-    uint32_t stop = 0;
-    RTC_AlarmTypeDef  alarmRtc;
+    TimerTick_t start;
+    TimerTick_t stop;
+    RTC_AlarmTypeDef alarmRtc;
     RtcCalendar_t now;
 
     if( WakeUpTimeInitialized == false )
@@ -379,8 +405,15 @@ static void RtcComputeWakeUpTime( void )
         now = RtcGetCalendar( );
         HAL_RTC_GetAlarm( &RtcHandle, &alarmRtc, RTC_ALARM_A, RTC_FORMAT_BIN );
 
-        start = PREDIV_S - alarmRtc.AlarmTime.SubSeconds;
-        stop = PREDIV_S - now.CalendarTime.SubSeconds;
+        start = alarmRtc.AlarmTime.Hours    * 3600 * (PREDIV_S + 1);
+        start += alarmRtc.AlarmTime.Minutes * 60   * (PREDIV_S + 1);
+        start += alarmRtc.AlarmTime.Seconds * 1    * (PREDIV_S + 1);
+        start += PREDIV_S - alarmRtc.AlarmTime.SubSeconds;
+
+        stop = now.CalendarTime.Hours * 3600 * (PREDIV_S + 1);
+        stop += now.CalendarTime.Minutes * 60 * (PREDIV_S + 1);
+        stop += now.CalendarTime.Seconds * (PREDIV_S + 1);
+        stop += PREDIV_S - now.CalendarTime.SubSeconds;
 
         McuWakeUpTime = RtcConvertTickToMs( stop - start );
 
@@ -388,7 +421,7 @@ static void RtcComputeWakeUpTime( void )
     }
 }
 
-static void RtcStartWakeUpAlarm( uint32_t timeoutValue )
+static void RtcStartWakeUpAlarm( TimerTick_t timeoutValue )
 {
     RtcCalendar_t now;
     RtcCalendar_t alarmTimer;
@@ -407,7 +440,7 @@ static void RtcStartWakeUpAlarm( uint32_t timeoutValue )
     // Save the calendar into RtcCalendarContext to be able to calculate the elapsed time
     RtcCalendarContext = now;
 
-    // timeoutValue is in ms
+    // timeoutValue is in subseconds
     alarmTimer = RtcComputeTimerTimeToAlarmTick( timeoutValue, now );
 
     alarmStructure.Alarm = RTC_ALARM_A;
@@ -428,56 +461,54 @@ static void RtcStartWakeUpAlarm( uint32_t timeoutValue )
     }
 }
 
-static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, RtcCalendar_t now )
+static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTick_t timeCounter, RtcCalendar_t now )
 {
     RtcCalendar_t calendar = now;
 
-    TimerTime_t timeoutValue = 0;
-
-    uint16_t milliseconds = 0;
+    uint32_t subseconds = PREDIV_S - now.CalendarTime.SubSeconds;
     uint16_t seconds = now.CalendarTime.Seconds;
     uint16_t minutes = now.CalendarTime.Minutes;
     uint16_t hours = now.CalendarTime.Hours;
-    uint16_t days = now.CalendarDate.Date;
+    uint16_t day = now.CalendarDate.Date;
+    uint8_t month = now.CalendarDate.Month;
+    uint16_t year = now.CalendarDate.Year;
 
-    timeoutValue = timeCounter;
+    // Extract the subseconds part from the timeCounter
+    subseconds += timeCounter % ( PREDIV_S + 1 );
 
-    milliseconds = PREDIV_S - now.CalendarTime.SubSeconds;
-    milliseconds += ( timeoutValue & PREDIV_S);
+    // Convert timeout to whole seconds
+    timeCounter /= ( PREDIV_S + 1 );
 
-    /* convert timeout  to seconds */
-    timeoutValue >>= N_PREDIV_S;  /* convert timeout  in seconds */
-
-    // Convert milliseconds to RTC format and add to now
-    while( timeoutValue >= SecondsInDay )
+    // Calculate the days
+    while( timeCounter >= SecondsInDay )
     {
-        timeoutValue -= SecondsInDay;
-        days++;
+        timeCounter -= SecondsInDay;
+        day++;
     }
 
-    // Calculate hours
-    while( timeoutValue >= SecondsInHour )
+    // Calculate the hours
+    while( timeCounter >= SecondsInHour )
     {
-        timeoutValue -= SecondsInHour;
+        timeCounter -= SecondsInHour;
         hours++;
     }
 
-    // Calculate minutes
-    while( timeoutValue >= SecondsInMinute )
+    // Calculate the minutes
+    while( timeCounter >= SecondsInMinute )
     {
-        timeoutValue -= SecondsInMinute;
+        timeCounter -= SecondsInMinute;
         minutes++;
     }
 
-    // Calculate seconds
-    seconds += timeoutValue;
-
-    // Correct for modulo
-    while( milliseconds >= ( PREDIV_S + 1 ) )
+    // Calculate the seconds
+    seconds += timeCounter;
+    while( subseconds >= ( PREDIV_S + 1 ) )
     {
-        milliseconds -= ( PREDIV_S + 1 );
+        subseconds -= ( PREDIV_S + 1 );
         seconds++;
     }
+
+    // Convert the calculated seconds and subseconds into a calendar
 
     while( seconds >= SecondsInMinute )
     {
@@ -494,31 +525,74 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
     while( hours >= HoursInDay )
     {
         hours -= HoursInDay;
-        days++;
+        day++;
     }
 
-    if( ( now.CalendarDate.Year == 0 ) || ( now.CalendarDate.Year % 4 ) == 0 )
+    for ( ;; )
     {
-        if( days > DaysInMonthLeapYear[now.CalendarDate.Month - 1] )
+        uint8_t cont = 0;
+
+        if( year % 4 == 0 )
         {
-            days = days % DaysInMonthLeapYear[now.CalendarDate.Month - 1];
-            calendar.CalendarDate.Month++;
+            while( day > DaysInMonthLeapYear[month - 1] )
+            {
+                day -= DaysInMonthLeapYear[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    cont = 1;
+                    break;
+                }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
+            }
+
+            // Calculations done
+            break;
         }
-    }
-    else
-    {
-        if( days > DaysInMonth[now.CalendarDate.Month - 1] )
+        else
         {
-            days = days % DaysInMonth[now.CalendarDate.Month - 1];
-            calendar.CalendarDate.Month++;
+            while( day > DaysInMonth[month - 1] )
+            {
+                day -= DaysInMonth[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    cont = 1;
+                    break;
+                }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
+            }
+
+            // Calculations done
+            break;
         }
     }
 
-    calendar.CalendarTime.SubSeconds = PREDIV_S - milliseconds;
+    calendar.CalendarTime.SubSeconds = PREDIV_S - subseconds;
     calendar.CalendarTime.Seconds = seconds;
     calendar.CalendarTime.Minutes = minutes;
     calendar.CalendarTime.Hours = hours;
-    calendar.CalendarDate.Date = days;
+    calendar.CalendarDate.Date = day;
+    calendar.CalendarDate.Month = month;
+    calendar.CalendarDate.Year = year;
 
     return calendar;
 }
@@ -526,59 +600,56 @@ static RtcCalendar_t RtcComputeTimerTimeToAlarmTick( TimerTime_t timeCounter, Rt
 //
 // REMARK: Removed function static attribute in order to suppress
 //         "#177-D function was declared but never referenced" warning.
-// static RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
+// static RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTick_t timeCounter )
 //
-RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
+RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTick_t timeCounter )
 {
     RtcCalendar_t calendar = { { 0 }, { 0 } };
 
-    TimerTime_t timeoutValue = 0;
-
-    uint16_t milliseconds = 0;
+    uint32_t subseconds;
     uint16_t seconds = 0;
     uint16_t minutes = 0;
     uint16_t hours = 0;
-    uint16_t days = 0;
-    uint8_t months = 1; // Start at 1, month 0 does not exist
-    uint16_t years = 0;
+    uint16_t day = 0;
+    uint8_t month = 1; // Start at 1, month 0 does not exist
+    uint16_t year = 0;
 
-    timeoutValue = timeCounter;
+    // Extract the subseconds part from the timeCounter
+    subseconds = timeCounter % ( PREDIV_S + 1 );
 
-    milliseconds += ( timeoutValue & PREDIV_S);
+    // Convert timeout to whole seconds
+    timeCounter /= ( PREDIV_S + 1 );
 
-    /* convert timeout  to seconds */
-    timeoutValue >>= N_PREDIV_S; // convert timeout  in seconds
-
-    // Convert milliseconds to RTC format and add to now
-    while( timeoutValue >= SecondsInDay )
+    // Calculate the day
+    while( timeCounter >= SecondsInDay )
     {
-        timeoutValue -= SecondsInDay;
-        days++;
+        timeCounter -= SecondsInDay;
+        day++;
     }
 
-    // Calculate hours
-    while( timeoutValue >= SecondsInHour )
+    // Calculate the hours
+    while( timeCounter >= SecondsInHour )
     {
-        timeoutValue -= SecondsInHour;
+        timeCounter -= SecondsInHour;
         hours++;
     }
 
-    // Calculate minutes
-    while( timeoutValue >= SecondsInMinute )
+    // Calculate the minutes
+    while( timeCounter >= SecondsInMinute )
     {
-        timeoutValue -= SecondsInMinute;
+        timeCounter -= SecondsInMinute;
         minutes++;
     }
 
-    // Calculate seconds
-    seconds += timeoutValue;
-
-    // Correct for modulo
-    while( milliseconds >= ( PREDIV_S + 1 ) )
+    // Calculate the seconds
+    seconds += timeCounter;
+    while( subseconds >= ( PREDIV_S + 1 ) )
     {
-        milliseconds -= ( PREDIV_S + 1 );
+        subseconds -= ( PREDIV_S + 1 );
         seconds++;
     }
+
+    // Convert the calculated seconds and subseconds into a calendar
 
     while( seconds >= SecondsInMinute )
     {
@@ -595,31 +666,88 @@ RtcCalendar_t RtcConvertTimerTimeToCalendarTick( TimerTime_t timeCounter )
     while( hours >= HoursInDay )
     {
         hours -= HoursInDay;
-        days++;
+        day++;
     }
 
-    while( days > DaysInMonthLeapYear[months - 1] )
+    while( hours >= HoursInDay )
     {
-        days -= DaysInMonthLeapYear[months - 1];
-        months++;
+        hours -= HoursInDay;
+        day++;
     }
 
-    calendar.CalendarTime.SubSeconds = PREDIV_S - milliseconds;
+    for ( ;; )
+    {
+        uint8_t cont = 0;
+
+        if( year % 4 == 0 )
+        {
+            while( day > DaysInMonthLeapYear[month - 1] )
+            {
+                day -= DaysInMonthLeapYear[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    cont = 1;
+                    break;
+                }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
+            }
+
+            // Calculations done
+            break;
+        }
+        else
+        {
+            while( day > DaysInMonth[month - 1] )
+            {
+                day -= DaysInMonth[month - 1];
+                month++;
+
+                if( month > 12 )
+                {
+                    month -= 12;
+                    year++;
+
+                    cont = 1;
+                    break;
+                }
+            }
+
+            if( cont )
+            {
+                // Year was changed, start from the scratch
+                continue;
+            }
+
+            // Calculations done
+            break;
+        }
+    }
+
+    calendar.CalendarTime.SubSeconds = PREDIV_S - subseconds;
     calendar.CalendarTime.Seconds = seconds;
     calendar.CalendarTime.Minutes = minutes;
     calendar.CalendarTime.Hours = hours;
-    calendar.CalendarDate.Date = days;
-    calendar.CalendarDate.Month = months;
-    calendar.CalendarDate.Year = years; // on 32-bit, years will never go up
+    calendar.CalendarDate.Date = day;
+    calendar.CalendarDate.Month = month;
+    calendar.CalendarDate.Year = year;
 
     return calendar;
 }
 
-static TimerTime_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar )
+static TimerTick_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar )
 {
-    TimerTime_t timeCounter = 0;
+    TimerTick_t timeCounter = 0;
     RtcCalendar_t now;
-    uint32_t timeCounterTemp = 0;
 
     // Passing a NULL pointer will compute from "now" else,
     // compute from the given calendar value
@@ -633,56 +761,64 @@ static TimerTime_t RtcConvertCalendarTickToTimerTime( RtcCalendar_t *calendar )
     }
 
     // Years (calculation valid up to year 2099)
-    for( int16_t i = 0; i < now.CalendarDate.Year ; i++ )
+    for( uint8_t i = 0; i < now.CalendarDate.Year ; i++ )
     {
-        if( ( i == 0 ) || ( i % 4 ) == 0 )
+        if( i % 4 == 0 )
         {
-            timeCounterTemp += ( uint32_t )SecondsInLeapYear;
+            timeCounter += SecondsInLeapYear;
         }
         else
         {
-            timeCounterTemp += ( uint32_t )SecondsInYear;
+            timeCounter += SecondsInYear;
         }
     }
 
     // Months (calculation valid up to year 2099)*/
-    if( ( now.CalendarDate.Year == 0 ) || ( now.CalendarDate.Year % 4 ) == 0 )
+    if( now.CalendarDate.Year % 4 == 0 )
     {
         for( uint8_t i = 0; i < ( now.CalendarDate.Month - 1 ); i++ )
         {
-            timeCounterTemp += ( uint32_t )( DaysInMonthLeapYear[i] * SecondsInDay );
+            timeCounter += ( DaysInMonthLeapYear[i] * SecondsInDay );
         }
     }
     else
     {
         for( uint8_t i = 0;  i < ( now.CalendarDate.Month - 1 ); i++ )
         {
-            timeCounterTemp += ( uint32_t )( DaysInMonth[i] * SecondsInDay );
+            timeCounter += ( DaysInMonth[i] * SecondsInDay );
         }
     }
 
-    timeCounterTemp += ( uint32_t )( ( uint32_t )now.CalendarTime.Seconds +
-                     ( ( uint32_t )now.CalendarTime.Minutes * SecondsInMinute ) +
-                     ( ( uint32_t )now.CalendarTime.Hours * SecondsInHour ) +
-                     ( ( uint32_t )( now.CalendarDate.Date * SecondsInDay ) ) );
+    timeCounter += ( now.CalendarTime.Seconds +
+                     ( now.CalendarTime.Minutes * SecondsInMinute ) +
+                     ( now.CalendarTime.Hours * SecondsInHour ) +
+                     ( now.CalendarDate.Date * SecondsInDay ) );
 
-    timeCounter = ( timeCounterTemp << N_PREDIV_S ) + ( PREDIV_S - now.CalendarTime.SubSeconds);
+    timeCounter *= (PREDIV_S + 1);
+
+    timeCounter += PREDIV_S - now.CalendarTime.SubSeconds;
 
     return ( timeCounter );
 }
 
-TimerTime_t RtcConvertMsToTick( TimerTime_t timeoutValue )
+TimerTick_t RtcConvertMsToTick( TimerTime_t timeoutValue )
 {
-    double retVal = 0;
-    retVal = round( ( ( double )timeoutValue * CONV_DENOM ) / CONV_NUMER );
-    return( ( TimerTime_t )retVal );
+#if (PREDIV_S + 1 == MSEC_NUMBER)
+    return ( TimerTick_t )timeoutValue;
+#else
+    double retVal = round( ( double )( timeoutValue * ( PREDIV_S + 1 ) ) / MSEC_NUMBER );
+    return( ( TimerTick_t )retVal );
+#endif
 }
 
-TimerTime_t RtcConvertTickToMs( TimerTime_t timeoutValue )
+TimerTime_t RtcConvertTickToMs( TimerTick_t timeoutValue )
 {
-    double retVal = 0.0;
-    retVal = round( ( ( double )timeoutValue * CONV_NUMER ) / CONV_DENOM );
+#if (PREDIV_S + 1 == MSEC_NUMBER)
+    return ( TimerTime_t )timeoutValue;
+#else
+    double retVal = round( ( double ) ( timeoutValue * MSEC_NUMBER ) / ( PREDIV_S + 1 ) );
     return( ( TimerTime_t )retVal );
+#endif
 }
 
 static RtcCalendar_t RtcGetCalendar( void )

--- a/src/boards/MoteII/rtc-board.h
+++ b/src/boards/MoteII/rtc-board.h
@@ -17,10 +17,11 @@ Maintainer: Miguel Luis and Gregory Cristian
 #define __RTC_BOARD_H__
 
 /*!
- * \brief Timer time variable definition
+ * \brief Timer time variable definition (time in milliseconds)
  */
 #ifndef TimerTime_t
-typedef uint32_t TimerTime_t;
+typedef uint64_t TimerTime_t;
+#define TIMERTIME_MAX ( (TimerTime_t) UINT64_MAX)
 #endif
 
 /*!
@@ -37,7 +38,7 @@ void RtcInit( void );
  *
  * \param[IN] timeout Duration of the Timer
  */
-void RtcSetTimeout( uint32_t timeout );
+void RtcSetTimeout( TimerTime_t timeout );
 
 /*!
  * \brief Adjust the value of the timeout to handle wakeup time from Alarm and GPIO irq
@@ -45,7 +46,7 @@ void RtcSetTimeout( uint32_t timeout );
  * \param[IN] timeout Duration of the Timer without compensation for wakeup time
  * \retval new value for the Timeout with compensations
  */
-TimerTime_t RtcGetAdjustedTimeoutValue( uint32_t timeout );
+TimerTime_t RtcGetAdjustedTimeoutValue( TimerTime_t timeout );
 
 /*!
  * \brief Get the RTC timer value

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -336,8 +336,8 @@ static TimerEvent_t RxWindowTimer2;
  * \remark normal frame: RxWindowXDelay = ReceiveDelayX - RADIO_WAKEUP_TIME
  *         join frame  : RxWindowXDelay = JoinAcceptDelayX - RADIO_WAKEUP_TIME
  */
-static uint32_t RxWindow1Delay;
-static uint32_t RxWindow2Delay;
+static TimerTime_t RxWindow1Delay;
+static TimerTime_t RxWindow2Delay;
 
 /*!
  * LoRaMac Rx windows configuration

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -170,7 +170,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            uint32_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
+            TimerTime_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
                                         ( dutyCycle == true ) ? TimerGetElapsedTime( bands[i].LastTxDoneTime ) : 0 );
 
             if( bands[i].TimeOff <= txDoneTime )

--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -253,7 +253,7 @@ bool SX1272IsChannelFree( RadioModems_t modem, uint32_t freq, int16_t rssiThresh
 {
     bool status = true;
     int16_t rssi = 0;
-    uint32_t carrierSenseTime = 0;
+    TimerTime_t carrierSenseTime = 0;
 
     SX1272SetModem( modem );
 
@@ -266,7 +266,7 @@ bool SX1272IsChannelFree( RadioModems_t modem, uint32_t freq, int16_t rssiThresh
     carrierSenseTime = TimerGetCurrentTime( );
 
     // Perform carrier sense for maxCarrierSenseTime
-    while( TimerGetElapsedTime( carrierSenseTime ) < maxCarrierSenseTime )
+    while( TimerGetElapsedTime( carrierSenseTime ) < (TimerTime_t) maxCarrierSenseTime )
     {
         rssi = SX1272ReadRssi( modem );
 

--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -262,7 +262,7 @@ bool SX1276IsChannelFree( RadioModems_t modem, uint32_t freq, int16_t rssiThresh
 {
     bool status = true;
     int16_t rssi = 0;
-    uint32_t carrierSenseTime = 0;
+    TimerTime_t carrierSenseTime = 0;
 
     SX1276SetModem( modem );
 

--- a/src/system/timer.c
+++ b/src/system/timer.c
@@ -36,7 +36,7 @@ static TimerEvent_t *TimerListHead = NULL;
  * \param [IN]  obj Timer object to be become the new head
  * \param [IN]  remainingTime Remaining time of the previous head to be replaced
  */
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime );
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
 
 /*!
  * \brief Adds a timer to the list.
@@ -47,7 +47,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
  * \param [IN]  obj Timer object to be added to the list
  * \param [IN]  remainingTime Remaining time of the running head after which the object may be added
  */
-static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime );
+static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime );
 
 /*!
  * \brief Sets a timeout with the duration "timestamp"
@@ -69,7 +69,7 @@ static bool TimerExists( TimerEvent_t *obj );
  *
  * \retval value current timer value
  */
-TimerTime_t TimerGetValue( void );
+static TimerTime_t TimerGetValue( void );
 
 void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 {
@@ -82,8 +82,8 @@ void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 
 void TimerStart( TimerEvent_t *obj )
 {
-    uint32_t elapsedTime = 0;
-    uint32_t remainingTime = 0;
+    TimerTime_t elapsedTime = 0;
+    TimerTime_t remainingTime = 0;
 
     BoardDisableIrq( );
 
@@ -128,10 +128,10 @@ void TimerStart( TimerEvent_t *obj )
     BoardEnableIrq( );
 }
 
-static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime )
+static void TimerInsertTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
 {
-    uint32_t aggregatedTimestamp = 0;      // hold the sum of timestamps
-    uint32_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
+    TimerTime_t aggregatedTimestamp = 0;      // hold the sum of timestamps
+    TimerTime_t aggregatedTimestampNext = 0;  // hold the sum of timestamps up to the next event
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead->Next;
@@ -182,7 +182,7 @@ static void TimerInsertTimer( TimerEvent_t *obj, uint32_t remainingTime )
     }
 }
 
-static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
+static void TimerInsertNewHeadTimer( TimerEvent_t *obj, TimerTime_t remainingTime )
 {
     TimerEvent_t* cur = TimerListHead;
 
@@ -200,7 +200,7 @@ static void TimerInsertNewHeadTimer( TimerEvent_t *obj, uint32_t remainingTime )
 
 void TimerIrqHandler( void )
 {
-    uint32_t elapsedTime = 0;
+    TimerTime_t elapsedTime = 0;
 
     // Early out when TimerListHead is null to prevent null pointer
     if ( TimerListHead == NULL )
@@ -247,8 +247,8 @@ void TimerStop( TimerEvent_t *obj )
 {
     BoardDisableIrq( );
 
-    uint32_t elapsedTime = 0;
-    uint32_t remainingTime = 0;
+    TimerTime_t elapsedTime = 0;
+    TimerTime_t remainingTime = 0;
 
     TimerEvent_t* prev = TimerListHead;
     TimerEvent_t* cur = TimerListHead;
@@ -351,14 +351,14 @@ void TimerReset( TimerEvent_t *obj )
     TimerStart( obj );
 }
 
-void TimerSetValue( TimerEvent_t *obj, uint32_t value )
+void TimerSetValue( TimerEvent_t *obj, TimerTime_t value )
 {
     TimerStop( obj );
     obj->Timestamp = value;
     obj->ReloadValue = value;
 }
 
-TimerTime_t TimerGetValue( void )
+static TimerTime_t TimerGetValue( void )
 {
     return RtcGetElapsedAlarmTime( );
 }

--- a/src/system/timer.h
+++ b/src/system/timer.h
@@ -16,23 +16,27 @@ Maintainer: Miguel Luis and Gregory Cristian
 #define __TIMER_H__
 
 /*!
+ * \brief TimerTime_t type definition
+ *
+ * \remark TimerTime_t is used for variables counting in milliseconds
+ *
+ */
+#ifndef TimerTime_t
+typedef uint64_t TimerTime_t;
+#define TIMERTIME_MAX ( (TimerTime_t) UINT64_MAX)
+#endif
+
+/*!
  * \brief Timer object description
  */
 typedef struct TimerEvent_s
 {
-    uint32_t Timestamp;         //! Current timer value
-    uint32_t ReloadValue;       //! Timer delay value
+    TimerTime_t Timestamp;         //! Current timer value
+    TimerTime_t ReloadValue;       //! Timer delay value
     bool IsRunning;             //! Is the timer currently running
     void ( *Callback )( void ); //! Timer IRQ callback function
     struct TimerEvent_s *Next;  //! Pointer to the next Timer object.
 }TimerEvent_t;
-
-/*!
- * \brief Timer time variable definition
- */
-#ifndef TimerTime_t
-typedef uint32_t TimerTime_t;
-#endif
 
 /*!
  * \brief Initializes the timer object
@@ -77,7 +81,7 @@ void TimerReset( TimerEvent_t *obj );
  * \param [IN] obj   Structure containing the timer object parameters
  * \param [IN] value New timer timeout value
  */
-void TimerSetValue( TimerEvent_t *obj, uint32_t value );
+void TimerSetValue( TimerEvent_t *obj, TimerTime_t value );
 
 /*!
  * \brief Read the current time


### PR DESCRIPTION
This is a rebase an small improvements over the work done by
LocatorCJSC <dev@locator.am> here:
https://github.com/LocatorCJSC/LoRaMac-node/tree/mote_ii_rtc_refactoring

The size of variables handling elapsed time, both in ms and in
timer ticks are increased from 32 to 64 bits in order to prevent
erroneous behaviour when the time wraps around.