### PR TITLE
fix Max TX Power in US915_HYBRID

### DIFF
--- a/src/mac/region/RegionUS915-Hybrid.h
+++ b/src/mac/region/RegionUS915-Hybrid.h
@@ -98,7 +98,7 @@
 /*!
  * Default Max ERP
  */
-#define US915_HYBRID_DEFAULT_MAX_ERP                30.0f
+#define US915_HYBRID_DEFAULT_MAX_ERP                21.0f
 
 /*!
  * ADR Ack limit


### PR DESCRIPTION
US915 use 64-72 channels and can transmit at +30dBm.
US915_HYBRID use only 8-16 channels and can only transmit at +21dBm.
     
text from LoRaWAN 1.1 Regional Parameters:
Frequency-Hopping, Spread-Spectrum (FHSS) mode, which requires the device transmit at a measured conducted power level no greater than +30 dBm, for a period of no more than 400 msec and over at least 50 channels, each of which occupy no greater than 250 kHz of bandwidth.

Hybrid mode, which requires that the device transmit over multiple channels (this may be less than the 50 channels required for FHSS mode, but is recommended to be at least 4) while complying with the Power Spectral Density requirements of DTS mode and the 400 msec  dwell time of FHSS mode.  In practice this limits the measured conducted power of the end-device to 21 dBm.