### PR TITLE
Unitialized variable 'datarate'

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3214,7 +3214,7 @@ LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest )
     uint8_t fPort = 0;
     void *fBuffer;
     uint16_t fBufferSize;
-    int8_t datarate;
+    int8_t datarate = DR_0;
     bool readyToSend = false;
 
     if( mcpsRequest == NULL )


### PR DESCRIPTION
When trying to compile this on macOS clang complained about the following:

    LoRaMac.c:3274:9: warning: variable 'datarate' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]