### PR TITLE
nnnnco.com.au change to fix RX2 frequency changes in Class C

### DIFF
--- a/src/apps/LoRaMac/classC/LoRaMote/main.c
+++ b/src/apps/LoRaMac/classC/LoRaMote/main.c
@@ -456,6 +456,13 @@ static void McpsIndication( McpsIndication_t *mcpsIndication )
         {
             break;
         }
+        case MCPS_FORCE_SEND:
+        {
+            // Force a new send
+            DeviceState = DEVICE_STATE_SEND;
+            NextTx = true;
+            break;
+        }
         default:
             break;
     }

--- a/src/apps/LoRaMac/classC/MoteII/main.c
+++ b/src/apps/LoRaMac/classC/MoteII/main.c
@@ -483,6 +483,13 @@ static void McpsIndication( McpsIndication_t *mcpsIndication )
         {
             break;
         }
+        case MCPS_FORCE_SEND:
+        {
+            // Force a new send
+            DeviceState = DEVICE_STATE_SEND;
+            NextTx = true;
+            break;
+        }
         default:
             break;
     }

--- a/src/apps/LoRaMac/classC/NAMote72/main.c
+++ b/src/apps/LoRaMac/classC/NAMote72/main.c
@@ -471,6 +471,13 @@ static void McpsIndication( McpsIndication_t *mcpsIndication )
         {
             break;
         }
+        case MCPS_FORCE_SEND:
+        {
+            // Force a new send
+            DeviceState = DEVICE_STATE_SEND;
+            NextTx = true;
+            break;
+        }
         default:
             break;
     }

--- a/src/apps/LoRaMac/classC/SK-iM880A/main.c
+++ b/src/apps/LoRaMac/classC/SK-iM880A/main.c
@@ -404,6 +404,13 @@ static void McpsIndication( McpsIndication_t *mcpsIndication )
         {
             break;
         }
+        case MCPS_FORCE_SEND:
+        {
+            // Force a new send
+            DeviceState = DEVICE_STATE_SEND;
+            NextTx = true;
+            break;
+        }
         default:
             break;
     }

--- a/src/apps/LoRaMac/classC/SensorNode/main.c
+++ b/src/apps/LoRaMac/classC/SensorNode/main.c
@@ -468,6 +468,13 @@ static void McpsIndication( McpsIndication_t *mcpsIndication )
         {
             break;
         }
+        case MCPS_FORCE_SEND:
+        {
+            // Force a new send
+            DeviceState = DEVICE_STATE_SEND;
+            NextTx = true;
+            break;
+        }
         default:
             break;
     }

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -644,6 +644,7 @@ typedef union eLoRaMacFlags_t
  * \ref MCPS_CONFIRMED   | YES     | YES        | NO       | YES
  * \ref MCPS_MULTICAST   | NO      | YES        | NO       | NO
  * \ref MCPS_PROPRIETARY | YES     | YES        | NO       | YES
+ * \ref MCPS_FORCE_SEND  | NO      | YES        | NO       | NO
  *
  * The following table provides links to the function implementations of the
  * related MCPS primitives:
@@ -672,6 +673,11 @@ typedef enum eMcps
      * Proprietary frame
      */
     MCPS_PROPRIETARY,
+    /*!
+     * Force send 
+     * Used to ensure MAC responses sent to server.
+     */
+    MCPS_FORCE_SEND,
 }Mcps_t;
 
 /*!


### PR DESCRIPTION
When SRV_MAC_RX_PARAM_SETUP_REQ is received, the MAC immediately changes the RX2 frequency to the new frequency as per the LoRa specification.
However, the server will not change its RX2 frequency until MOTE_MAC_RX_PARAM_SETUP_ANS MAC response is received.
A MAC response can only be sent to the server if the application performs a LoRaMacMcpsRequest MCPS_UNCONFIRMED or MCPS_CONFIRMED to send data.
A  Class C device will be listening on the(now potentially wrong RX2 frequency until the next LoRaMacMcpsRequest MCPS_UNCONFIRMED or MCPS_CONFIRMED is performed.

A new MCPS_FORCE_SEND indication has been added inform the application that a LoRaMacMcpsRequest MCPS_UNCONFIRMED or MCPS_CONFIRMED
is reqiuired by the MAC layer. The application layer may schedule a  LoRaMacMcpsRequest MCPS_UNCONFIRMED or MCPS_CONFIRMED at its convenience.

If a Class C device does not require this functionality, the MCPS_FORCE_SEND indication can be ignored.

Changes:
- Added new MCPS_FORCE_SEND
- Added RXParamSetupWaitingForRx flag to indicate we are waiting for a server response after sending MOTE_MAC_RX_PARAM_SETUP_ANS response
- Added RXParamSetupWaitingForRxTimeoutTimer to retry MCPS_FORCE_SEND if no response from server is detected
- Updared Class C examples