### PR TITLE
Fix for incorrect return code from RegionVerify(PHY_NB_JOIN_TRIALS)

### DIFF
--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -371,14 +371,14 @@ bool RegionAU915Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 2 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionAU915ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -351,14 +351,14 @@ bool RegionCN470Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionCN470ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -366,14 +366,14 @@ bool RegionCN779Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionCN779ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -366,14 +366,14 @@ bool RegionEU433Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionEU433ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -395,14 +395,14 @@ bool RegionEU868Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionEU868ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -370,14 +370,14 @@ bool RegionIN865Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionIN865ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -389,14 +389,14 @@ bool RegionKR920Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 48 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionKR920ApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionUS915-Hybrid.c
+++ b/src/mac/region/RegionUS915-Hybrid.c
@@ -468,14 +468,14 @@ bool RegionUS915HybridVerify( VerifyParams_t* verify, PhyAttribute_t phyAttribut
         {
             if( verify->NbJoinTrials < 2 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionUS915HybridApplyCFList( ApplyCFListParams_t* applyCFList )

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -381,14 +381,14 @@ bool RegionUS915Verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
         {
             if( verify->NbJoinTrials < 2 )
             {
-                return false;
+                return true;
             }
             break;
         }
         default:
-            return false;
+            break;
     }
-    return true;
+    return false;
 }
 
 void RegionUS915ApplyCFList( ApplyCFListParams_t* applyCFList )


### PR DESCRIPTION
This change addresses https://github.com/Lora-net/LoRaMac-node/issues/353

When no response is received to a Join Request, the MAC retries the
join up to 48 times despite the fact that it is configured for only
one trial. Investigation reveals that this is due to an incorrect
test in all regional modules.

The fix is to simply return true instead of false when the test succeeds.

In addition, the default return value from the Region*Verify() function
has been changed to false (after checking that no case other than
unrecognized test values breaks out of the switch/case statement)

modified:   StackforceMAC/src/Semtech/mac/region/RegionAU915.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionCN470.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionCN779.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionEU433.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionEU868.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionIN865.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionKR920.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionUS915-Hybrid.c
modified:   StackforceMAC/src/Semtech/mac/region/RegionUS915.c

    RegionXXXXVerify()

	Fixed the return condition to properly validate the NbJointrials
	parameter and return true if that parameter is within the valid
	range.