### PR TITLE
Issue #400 - Incorrect beacon channel after crc0 error

### DIFF
--- a/src/mac/LoRaMacClassB.c
+++ b/src/mac/LoRaMacClassB.c
@@ -967,7 +967,11 @@ bool LoRaMacClassBRxBeacon( uint8_t *payload, uint16_t size )
                 // The GwSpecific field contains 1 byte InfoDesc and 6 bytes Info
                 LoRaMacClassBParams.MlmeIndication->BeaconInfo.GwSpecific.InfoDesc = payload[phyParam.BeaconFormat.Rfu1Size + 4 + 2];
                 memcpy1( LoRaMacClassBParams.MlmeIndication->BeaconInfo.GwSpecific.Info, &payload[phyParam.BeaconFormat.Rfu1Size + 4 + 2 + 1], 6 );
-                beaconReceived = true;
+                
+                // Only indicate a beacon was received if beacon time was updated (i.e. crc0 validation passed); otherwise, subsequent
+                // beacon channel calculations will be wrong.
+                // handling to update beacon time
+                // beaconReceived = true;
             }
 
             // Reset beacon variables, if one of the crc is valid


### PR DESCRIPTION
This is my change to ensure beacon time is updated when it is not valid in the frame. With this change, beacon time will be updated later in the BEACON_STATE_MISSED case statement.  

Not knowing the implementation well enough, perhaps there is reason to instead continue to set beaconReceived=true if only crc1 is ok and adjust beacon time in this routine instead of the miss state handler. 