### PR TITLE
GCC: fix union initializers

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -884,7 +884,7 @@ void RadioSend( uint8_t *buffer, uint8_t size )
 
 void RadioSleep( void )
 {
-    SleepParams_t params = { 0 };
+    SleepParams_t params = { .Value = 0 };
 
     params.Fields.WarmStart = 1;
     SX126xSetSleep( params );


### PR DESCRIPTION
When a union variable is initialized, you should specify which member of the union you are using. Without this patch, a warning occurs with a strict gcc.

Source documentation [union initializer section] :
https://gcc.gnu.org/onlinedocs/gcc/Designated-Inits.html

Without this fix, I have this warning/error:
src/radio/sx126x/radio.c:887:5: error: missing braces around initializer [-Werror=missing-braces]
     SleepParams_t params = { 0 };
     ^
