### PR TITLE
Remove ACMA regulation in region AU915

### DIFF
--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -384,17 +384,6 @@ void RegionAU915ApplyCFList( ApplyCFListParams_t* applyCFList )
 
 bool RegionAU915ChanMaskSet( ChanMaskSetParams_t* chanMaskSet )
 {
-    uint8_t nbChannels = RegionCommonCountChannels( chanMaskSet->ChannelsMaskIn, 0, 4 );
-
-    // Check the number of active channels
-    // According to ACMA regulation, we require at least 20 125KHz channels, if
-    // the node shall utilize 125KHz channels.
-    if( ( nbChannels < 20 ) &&
-        ( nbChannels > 0 ) )
-    {
-        return false;
-    }
-
     switch( chanMaskSet->ChannelsMaskType )
     {
         case CHANNELS_MASK:


### PR DESCRIPTION
Remove ACMA regulation in region AU915 as it was removed in Regional Parameters v1.0.2rB

issue https://github.com/Lora-net/LoRaMac-node/issues/451