### PR TITLE
Rx2: stop the radio in classC before re-configuring it

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1491,6 +1491,7 @@ static void OnRxWindow2TimerEvent( void )
     }
     else
     {
+        Radio.Standby( );
         // Setup continuous listening for class c
         RxWindow2Config.RxContinuous = true;
     }


### PR DESCRIPTION
In the `OnRxWindow1TimerEvent`, the radio is turned-off in classC (line 1471).
But in the `OnRxWindow2TimerEvent`, the radio is not turned-off in classC (both on the slot before Rx1, and after the Rx1).

With the sx127x, it is not a problem because the radio is turned-off into the IRQ process. But with the sx1261, this process is not done, and this transceiver is not able to receive a message in classC into its Rx2 window. 

Two options are possibles:
- Make the code symetric between Rx1 & rx2 windows (this is my pull request).
- Make the code symetric between trasnceiver status treatement into IRQ process (i think it is less robust, due to differences between tranceivers).