### PR TITLE
SX126X: Fixed Rx2 Issue in Class C and the function "printf()" can't work issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tmp/
 .directory
 launch.json
 .cmaketools.json
+LoRaWAN-Node-Git.si4project/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,5 +17,6 @@
 ##
 cmake_minimum_required(VERSION 3.6)
 
+add_definitions(-D USE_TCXO)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/src/apps/LoRaMac/classC/NucleoL152/main.c
+++ b/src/apps/LoRaMac/classC/NucleoL152/main.c
@@ -849,6 +849,7 @@ int main( void )
             {
                 if( NextTx == true )
                 {
+                    printf("---------SendFrame--------\r\n");
                     PrepareTxFrame( AppPort );
 
                     NextTx = SendFrame( );

--- a/src/apps/LoRaMac/classC/NucleoL152/main.c
+++ b/src/apps/LoRaMac/classC/NucleoL152/main.c
@@ -22,12 +22,15 @@
  */
 
 /*! \file classC/NucleoL152/main.c */
+#include <stdio.h>
 
 #include "utilities.h"
 #include "board.h"
 #include "gpio.h"
 #include "LoRaMac.h"
 #include "Commissioning.h"
+
+#define ACTIVE_REGION LORAMAC_REGION_AS923
 
 #ifndef ACTIVE_REGION
 
@@ -63,7 +66,7 @@
  *
  * \remark Please note that when ADR is enabled the end-device should be static
  */
-#define LORAWAN_ADR_ON                              1
+#define LORAWAN_ADR_ON                              0
 
 #if defined( REGION_EU868 )
 
@@ -834,6 +837,9 @@ int main( void )
                 mibReq.Type = MIB_NETWORK_JOINED;
                 mibReq.Param.IsNetworkJoined = true;
                 LoRaMacMibSetRequestConfirm( &mibReq );
+
+                printf("ABP MODE, ");
+                printf("DevAddr=%08X\r\n",DevAddr);
 
                 DeviceState = DEVICE_STATE_SEND;
 #endif

--- a/src/boards/NucleoL152/board.c
+++ b/src/boards/NucleoL152/board.c
@@ -20,6 +20,7 @@
  *
  * \author    Gregory Cristian ( Semtech )
  */
+#include "stdio.h"
 #include "stm32l1xx.h"
 #include "utilities.h"
 #include "gpio.h"
@@ -374,6 +375,16 @@ int fputc( int c, FILE *stream )
     while( UartPutChar( &Uart2, c ) != 0 );
     return c;
 }
+
+int _write(int fd, char *pBuffer, int size)// for gcc 
+{
+    //HAL_UART_Transmit(&Uart2, pBuffer, size, 0xff);
+    for (int i = 0; i < size; i++){
+        while( UartPutChar( &Uart2, pBuffer[i] ) != 0 );
+    }
+    return size;
+}
+
 
 #ifdef USE_FULL_ASSERT
 /*

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2143,6 +2143,7 @@ static bool IsFPortAllowed( uint8_t fPort )
 
 static void OpenContinuousRx2Window( void )
 {
+    RxWindow2Config.WindowTimeout = 0;
     OnRxWindow2TimerEvent( );
     RxSlot = RX_SLOT_WIN_CLASS_C;
 }

--- a/src/radio/sx126x/sx126x.c
+++ b/src/radio/sx126x/sx126x.c
@@ -40,7 +40,9 @@ typedef struct
 /*!
  * \brief Holds the internal operating mode of the radio
  */
-static RadioOperatingModes_t OperatingMode;
+//static RadioOperatingModes_t OperatingMode;
+RadioOperatingModes_t OperatingMode;
+
 
 /*!
  * \brief Stores the current packet type set in the radio
@@ -261,6 +263,8 @@ void SX126xSetTx( uint32_t timeout )
 void SX126xSetRx( uint32_t timeout )
 {
     uint8_t buf[3];
+
+    printf("SX126xSetRx()\r\n");
 
     OperatingMode = MODE_RX;
 


### PR DESCRIPTION
Below are my experience and solutions on developing LoRaWAN Class C on SX1262.

Hardware: NUCLEO-L152RE + SX1262DVK1DAS.
cmake settings:
cmake -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain-arm-none-eabi.cmake" ^
      -DCMAKE_SH="CMAKE_SH-NOTFOUND" ^
      -DTOOLCHAIN_PREFIX="C:/Program Files (x86)/GNU Tools ARM Embedded/7 2017-q4-major" ^
      -DAPPLICATION="LoRaMac" ^
      -DCLASS="classC" ^
      -DACTIVE_REGION="LORAMAC_REGION_AS923" ^
      -DMODULATION="LORA" ^
      -DBOARD="NucleoL152" ^
      -DMBED_RADIO_SHIELD="SX1262DVK1DAS" ^
      -DREGION_EU868="OFF" ^
      -DREGION_US915="OFF" ^
      -DREGION_CN779="OFF" ^
      -DREGION_EU433="OFF" ^
      -DREGION_AU915="OFF" ^
      -DREGION_AS923="ON" ^
      -DREGION_CN470="OFF" ^
      -DREGION_KR920="OFF" ^
      -DREGION_IN865="OFF" ^
      -DREGION_US915_HYBRID="OFF" ^
      -G "MSYS Makefiles" ..

after testing, we could find that 1) the "printf()" function could not work(for me the "dbg tool" is hard to use, so I first should make the UART and "printf()" working to debug the project) . 2)track the Rx2 process, and found that the RF chip didn't enter rx mode while the MAC layer requires opening Rx2.

below are the solutions:
1) fix printf() issue. The implementation of "printf" is different between GCC and KEIL compiler. In the GCC, the "printf" function should be redefined by "int _write(int fd, char *pBuffer, int size)" .

File location "src/boards/NucleoL152/board.c"
+int _write(int fd, char *pBuffer, int size)// for gcc 
+{
+    //HAL_UART_Transmit(&Uart2, pBuffer, size, 0xff);
+    for (int i = 0; i < size; i++){
+        while( UartPutChar( &Uart2, pBuffer[i] ) != 0 );
+    }
+    return size;
+}

2) RX2 Issue. 
First, the SX126x driver code didn't provide a right chip state, because the variable OperatingMode in sx126x.c didn't update the state after TxDone/RxDone/...interruption, actually, the chip has automatically turned back to standby mode after TxDone/RxDone/......(changed file ""void RadioIrqProcess( void )")

File location "src/radio/sx126x/radio.c"
void RadioIrqProcess( void )
//....
         if( ( irqRegs & IRQ_TX_DONE ) == IRQ_TX_DONE )
         {
 +            OperatingMode = MODE_STDBY_RC;
             TimerStop( &TxTimeoutTimer );
//....

Second, We should set the last Rx2 window to continuous mode in Class C, this is the difference from Clase A ,   so we should set the rx timeout value to 0.(change file)

File location "src/mac/LoRaMac.c"
 static void OpenContinuousRx2Window( void )
 {
+    RxWindow2Config.WindowTimeout = 0;
     OnRxWindow2TimerEvent( );
     RxSlot = RX_SLOT_WIN_CLASS_C;
 }

