### PR TITLE
Properly use critical section

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1351,13 +1351,15 @@ static void ProcessRadioRxTimeout( void )
 
 static void LoRaMacHandleIrqEvents( void )
 {
-    LoRaMacRadioEvents_t events = LoRaMacRadioEvents;
+    LoRaMacRadioEvents_t events;
+
+    CRITICAL_SECTION_BEGIN( );
+    events = LoRaMacRadioEvents;
+    LoRaMacRadioEvents.Value = 0;
+    CRITICAL_SECTION_END( );
+
     if( events.Value != 0 )
     {
-        CRITICAL_SECTION_BEGIN( );
-        LoRaMacRadioEvents.Value = 0;
-        CRITICAL_SECTION_END( );
-
         if( events.Events.TxDone == 1 )
         {
             ProcessRadioTxDone( );

--- a/src/mac/LoRaMacClassB.c
+++ b/src/mac/LoRaMacClassB.c
@@ -1651,13 +1651,15 @@ void LoRaMacClassBSetMulticastPeriodicity( MulticastCtx_t* multicastChannel )
 void LoRaMacClassBProcess( void )
 {
 #ifdef LORAMAC_CLASSB_ENABLED
-    LoRaMacClassBEvents_t events = LoRaMacClassBEvents;
+    LoRaMacClassBEvents_t events;
+
+    CRITICAL_SECTION_BEGIN( );
+    events = LoRaMacClassBEvents;
+    LoRaMacClassBEvents.Value = 0;
+    CRITICAL_SECTION_END( );
+
     if( events.Value != 0 )
     {
-        CRITICAL_SECTION_BEGIN( );
-        LoRaMacClassBEvents.Value = 0;
-        CRITICAL_SECTION_END( );
-
         if( events.Events.Beacon == 1 )
         {
             LoRaMacClassBProcessBeacon( );


### PR DESCRIPTION
The critical section was not actually protecting the variable as it is read, but could change prior to the critical section start.
With this change, the variable is read and reset inside the critical section in order to make this atomic and not miss any events.