### PR TITLE
Fix txDoneTime variable type in RegionCommonUpdateBandTimeOff

### DIFF
--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -169,7 +169,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            uint32_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
+            TimerTime_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
                                         ( dutyCycle == true ) ? TimerGetElapsedTime( bands[i].LastTxDoneTime ) : 0 );
 
             if( bands[i].TimeOff <= txDoneTime )


### PR DESCRIPTION
The txDoneTime variable should be a TimerTime_t, not a uint32_t.