### PR TITLE
Make RegionCommonUpdateBandTimeOff return 0 instead of -1

### DIFF
--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -162,7 +162,7 @@ void RegionCommonSetBandTxDone( bool joined, Band_t* band, TimerTime_t lastTxDon
 
 TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* bands, uint8_t nbBands )
 {
-    TimerTime_t nextTxDelay = ( TimerTime_t )( -1 );
+    TimerTime_t nextTxDelay = TIMERTIME_T_MAX;
 
     // Update bands Time OFF
     for( uint8_t i = 0; i < nbBands; i++ )
@@ -202,7 +202,8 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
             }
         }
     }
-    return nextTxDelay;
+
+    return nextTxDelay==TIMERTIME_T_MAX?0:nextTxDelay;
 }
 
 uint8_t RegionCommonParseLinkAdrReq( uint8_t* payload, RegionCommonLinkAdrParams_t* linkAdrParams )

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -203,7 +203,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
         }
     }
 
-    return nextTxDelay==TIMERTIME_T_MAX?0:nextTxDelay;
+    return ( nextTxDelay == TIMERTIME_T_MAX ) ? 0 : nextTxDelay;
 }
 
 uint8_t RegionCommonParseLinkAdrReq( uint8_t* payload, RegionCommonLinkAdrParams_t* linkAdrParams )

--- a/src/system/timer.h
+++ b/src/system/timer.h
@@ -46,6 +46,7 @@ typedef struct TimerEvent_s
  */
 #ifndef TimerTime_t
 typedef uint32_t TimerTime_t;
+#define TIMERTIME_T_MAX (~0)
 #endif
 
 /*!


### PR DESCRIPTION
In rare circumstances, RegionCommonUpdateBandTimeOff might return the initial value of nextTxDelay, which is -1.
For clarity, TIMERTIME_T_MAX is introduced to replace "-1" as the maximum value for the TimerTime_t type.