### PR TITLE
Flag to make encryption state of payload explicit in LoRaMacCryptoSecureMessage

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2609,6 +2609,7 @@ LoRaMacStatus_t PrepareFrame( LoRaMacHeader_t* macHdr, LoRaMacFrameCtrl_t* fCtrl
             MacCtx.TxMsg.Message.Data.FHDR.FCtrl.Value = fCtrl->Value;
             MacCtx.TxMsg.Message.Data.FRMPayloadSize = MacCtx.AppDataSize;
             MacCtx.TxMsg.Message.Data.FRMPayload = MacCtx.AppData;
+            MacCtx.TxMsg.Message.Data.FRMPayloadEncrypted = false;
 
             if( LORAMAC_FCNT_HANDLER_SUCCESS != LoRaMacGetFCntUp( &fCntUp ) )
             {
@@ -2664,6 +2665,7 @@ LoRaMacStatus_t PrepareFrame( LoRaMacHeader_t* macHdr, LoRaMacFrameCtrl_t* fCtrl
 
                     MacCtx.TxMsg.Message.Data.FRMPayload = MacCtx.NvmCtx->MacCommandsBuffer;
                     MacCtx.TxMsg.Message.Data.FRMPayloadSize = macCmdsSize;
+                    MacCtx.TxMsg.Message.Data.FRMPayloadEncrypted = false;
                 }
             }
 

--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -1354,13 +1354,14 @@ LoRaMacCryptoStatus_t LoRaMacCryptoSecureMessage( uint32_t fCntUp, uint8_t txDr,
         FRMPayloadDecryptionKeyID = NWK_S_ENC_KEY;
     }
 
-    if( fCntUp > CryptoCtx.NvmCtx->FCntUp )
+    if ( !macMsg->FRMPayloadEncrypted )
     {
         retval = PayloadEncrypt( macMsg->FRMPayload, macMsg->FRMPayloadSize, FRMPayloadDecryptionKeyID, macMsg->FHDR.DevAddr, UPLINK, fCntUp );
         if( retval != LORAMAC_CRYPTO_SUCCESS )
         {
             return retval;
         }
+        macMsg->FRMPayloadEncrypted = true;
 
         if( CryptoCtx.LrWanVersion.Fields.Minor == 1 )
         {

--- a/src/mac/LoRaMacMessageTypes.h
+++ b/src/mac/LoRaMacMessageTypes.h
@@ -270,6 +270,10 @@ typedef struct sLoRaMacMessageData
      */
     uint8_t FRMPayloadSize;
     /*!
+     * Flag indicating if payload has been encrypted already
+     */
+    bool FRMPayloadEncrypted;
+    /*!
      * Message integrity code (MIC)
      */
     uint32_t MIC;


### PR DESCRIPTION
In rare cases, e.g. when a Tx has timed out, the CryptoNvm context will keep an invalid (already incremented) value for fcntUp, leading to the situation that the next message is sent in clear text, and subsequently received as garbage by the unknowing backend system that attempts to decrypt it.

This patch makes the encrypion state explicit in struct sLoRaMacMessageData.