### PR TITLE
Make uses of TimerGetElapsedTime(t) aware of t==0 situation

### DIFF
--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -917,7 +917,7 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -917,7 +917,7 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -917,8 +917,8 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -917,8 +917,8 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -917,7 +917,8 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -933,7 +934,7 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -917,8 +917,8 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -917,8 +917,8 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -917,7 +917,7 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -917,7 +917,7 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -917,7 +917,8 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -933,7 +934,7 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -734,8 +734,8 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[5] = 0xFFFF;
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -734,7 +734,7 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[5] = 0xFFFF;
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -734,7 +734,7 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[5] = 0xFFFF;
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -734,8 +734,8 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[5] = 0xFFFF;
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -734,7 +734,8 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[5] = 0xFFFF;
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -750,7 +751,7 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -860,7 +860,7 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -860,8 +860,8 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -860,8 +860,8 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -860,7 +860,7 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -860,7 +860,8 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -876,7 +877,7 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -169,10 +169,10 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            TimerTime_t elapsed_join = ( bands[i].LastJoinTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
-            TimerTime_t elapsed_tx = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
-            TimerTime_t txDoneTime =  MAX( elapsed_join,
-                                        ( dutyCycle == true ) ? elapsed_tx : 0 );
+            TimerTime_t elapsedJoin = ( bands[i].LastJoinTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
+            TimerTime_t elapsedTx = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
+            TimerTime_t txDoneTime =  MAX( elapsedJoin,
+                                        ( dutyCycle == true ) ? elapsedTx : 0 );
 
             if( bands[i].TimeOff <= txDoneTime )
             {

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -169,8 +169,8 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            TimerTime_t elapsedJoin = ( bands[i].LastJoinTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
-            TimerTime_t elapsedTx = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
+            TimerTime_t elapsedJoin = TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
+            TimerTime_t elapsedTx = TimerGetElapsedTime( bands[i].LastTxDoneTime );
             TimerTime_t txDoneTime =  MAX( elapsedJoin,
                                         ( dutyCycle == true ) ? elapsedTx : 0 );
 
@@ -187,7 +187,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
         {
             if( dutyCycle == true )
             {
-                TimerTime_t elapsed = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
+                TimerTime_t elapsed = TimerGetElapsedTime( bands[i].LastTxDoneTime );
                 if( bands[i].TimeOff <= elapsed )
                 {
                     bands[i].TimeOff = 0;

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -169,8 +169,8 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            TimerTime_t elapsed_join = bands[i].LastJoinTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
-            TimerTime_t elapsed_tx = bands[i].LastTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastTxDoneTime );
+            TimerTime_t elapsed_join = ( bands[i].LastJoinTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
+            TimerTime_t elapsed_tx = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
             TimerTime_t txDoneTime =  MAX( elapsed_join,
                                         ( dutyCycle == true ) ? elapsed_tx : 0 );
 
@@ -187,7 +187,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
         {
             if( dutyCycle == true )
             {
-                TimerTime_t elapsed = bands[i].LastTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastTxDoneTime );
+                TimerTime_t elapsed = ( bands[i].LastTxDoneTime == 0 ) ? 0 : TimerGetElapsedTime( bands[i].LastTxDoneTime );
                 if( bands[i].TimeOff <= elapsed )
                 {
                     bands[i].TimeOff = 0;

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -185,14 +185,14 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
         {
             if( dutyCycle == true )
             {
-                if( bands[i].TimeOff <= TimerGetElapsedTime( bands[i].LastTxDoneTime ) )
+                TimerTime_t elapsed = TimerGetElapsedTime( bands[i].LastTxDoneTime );
+                if( bands[i].TimeOff <= elapsed )
                 {
                     bands[i].TimeOff = 0;
                 }
                 if( bands[i].TimeOff != 0 )
                 {
-                    nextTxDelay = MIN( bands[i].TimeOff - TimerGetElapsedTime( bands[i].LastTxDoneTime ),
-                                       nextTxDelay );
+                    nextTxDelay = MIN( bands[i].TimeOff - elapsed, nextTxDelay );
                 }
             }
             else

--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -169,8 +169,10 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
     {
         if( joined == false )
         {
-            TimerTime_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
-                                        ( dutyCycle == true ) ? TimerGetElapsedTime( bands[i].LastTxDoneTime ) : 0 );
+            TimerTime_t elapsed_join = bands[i].LastJoinTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastJoinTxDoneTime );
+            TimerTime_t elapsed_tx = bands[i].LastTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastTxDoneTime );
+            TimerTime_t txDoneTime =  MAX( elapsed_join,
+                                        ( dutyCycle == true ) ? elapsed_tx : 0 );
 
             if( bands[i].TimeOff <= txDoneTime )
             {
@@ -185,7 +187,7 @@ TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, bool dutyCycle, Band_t* 
         {
             if( dutyCycle == true )
             {
-                TimerTime_t elapsed = TimerGetElapsedTime( bands[i].LastTxDoneTime );
+                TimerTime_t elapsed = bands[i].LastTxDoneTime==0?0:TimerGetElapsedTime( bands[i].LastTxDoneTime );
                 if( bands[i].TimeOff <= elapsed )
                 {
                     bands[i].TimeOff = 0;

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -860,7 +860,7 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -860,8 +860,8 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -860,8 +860,8 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -860,7 +860,7 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -860,7 +860,8 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -876,7 +877,7 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -892,8 +892,8 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -892,8 +892,8 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -892,7 +892,7 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -892,7 +892,7 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -892,7 +892,8 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -908,7 +909,7 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -885,8 +885,8 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -885,7 +885,7 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -885,7 +885,7 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -885,8 +885,8 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -885,7 +885,8 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -901,7 +902,7 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -854,8 +854,8 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -854,7 +854,7 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -854,7 +854,7 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -854,8 +854,8 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -854,7 +854,8 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -870,7 +871,7 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -851,7 +851,7 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -851,8 +851,8 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -851,7 +851,7 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -851,7 +851,8 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -867,7 +868,7 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -851,8 +851,8 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
         NvmCtx.ChannelsMask[0] |= LC( 1 ) + LC( 2 );
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -1009,7 +1009,7 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -1009,8 +1009,8 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = nextChanParams->LastAggrTx==0?0:TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -1009,8 +1009,8 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = ( nextChanParams->LastAggrTx == 0 ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
-    if( nextChanParams->LastAggrTx == 0 || nextChanParams->AggrTimeOff <= elapsed )
+    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -1009,7 +1009,7 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    TimerTime_t elapsed = ( ( nextChanParams->LastAggrTx == 0 ) ) ? 0 : TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
     if( ( nextChanParams->LastAggrTx == 0 ) || ( nextChanParams->AggrTimeOff <= elapsed ) )
     {
         // Reset Aggregated time off

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -1009,7 +1009,8 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
         }
     }
 
-    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    TimerTime_t elapsed = TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    if( nextChanParams->AggrTimeOff <= elapsed )
     {
         // Reset Aggregated time off
         *aggregatedTimeOff = 0;
@@ -1025,7 +1026,7 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
     else
     {
         delayTx++;
-        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+        nextTxDelay = nextChanParams->AggrTimeOff - elapsed;
     }
 
     if( nbEnabledChannels > 0 )

--- a/src/system/timer.c
+++ b/src/system/timer.c
@@ -351,6 +351,10 @@ TimerTime_t TimerGetCurrentTime( void )
 
 TimerTime_t TimerGetElapsedTime( TimerTime_t past )
 {
+    if ( past == 0 )
+    {
+        return 0;
+    }
     uint32_t nowInTicks = RtcGetTimerValue( );
     uint32_t pastInTicks = RtcMs2Tick( past );
 

--- a/src/system/timer.h
+++ b/src/system/timer.h
@@ -121,6 +121,8 @@ TimerTime_t TimerGetCurrentTime( void );
 /*!
  * \brief Return the Time elapsed since a fix moment in Time
  *
+ * \remark TimerGetElapsedTime will return 0 for argument 0.
+ *
  * \param [IN] past         fix moment in Time
  * \retval time             returns elapsed time
  */


### PR DESCRIPTION
Unset timestamps typically have value 0. For t==0, TimerGetElapsedTime(t) will return arbitrary values (depending on system uptime and initial system tick value) which might lead to non-intended behavior.

These fixes make the case for t==0 explicit, by assuming zero elapsed time.

(please note that this pull request necessarily includes an already approved but not yet applied commit 13982ff)