### PR TITLE
Updated RegionAU915.h

### DIFF
--- a/src/mac/region/RegionAU915.h
+++ b/src/mac/region/RegionAU915.h
@@ -292,7 +292,7 @@ static const int8_t DatarateOffsetsAU915[7][6] =
  * Maximum payload with respect to the datarate index. Cannot operate with repeater.
  * The table is valid for the dwell time configuration of 0 for uplinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell0AU915[] = { 51, 51, 51, 115, 242, 242, 242, 242, 0, 53, 129, 242, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateDwell0AU915[] = { 51, 51, 51, 115, 242, 242, 242, 0, 53, 129, 242, 242, 242, 242 };
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with repeater.
@@ -305,14 +305,14 @@ static const uint8_t MaxPayloadOfDatarateRepeaterDwell0AU915[] = { 51, 51, 51, 1
  * Maximum payload with respect to the datarate index. Cannot operate with repeater.
  * The table is valid for the dwell time configuration of 1 for uplinks.
  */
-static const uint8_t MaxPayloadOfDatarateDwell1AU915[] = { 0, 0, 11, 53, 125, 242, 242, 0, 53, 129, 129, 242, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateDwell1AU915[] = { 0, 0, 11, 53, 125, 242, 242, 0, 53, 129, 242, 242, 242, 242 };
 
 /*!
  * Maximum payload with respect to the datarate index. Can operate with repeater.
  * The table is valid for the dwell time configuration of 1 for uplinks. The table provides
  * repeater support.
  */
-static const uint8_t MaxPayloadOfDatarateRepeaterDwell1AU915[] = { 0, 0, 11, 53, 125, 242, 242, 0, 33, 119, 129, 242, 242, 242, 242 };
+static const uint8_t MaxPayloadOfDatarateRepeaterDwell1AU915[] = { 0, 0, 11, 53, 125, 242, 242, 0, 33, 109, 222, 222, 222, 222 };
 
 /*!
  * \brief The function gets a value of a specific phy attribute.


### PR DESCRIPTION
Corrected the values of the arrays MaxPayloadOfDatarateDwell0AU915, MaxPayloadOfDatarateDwell1AU915 and MaxPayloadOfDatarateRepeaterDwell1AU915, according to the Regional Specs v1.0.3.
This was causing failure during join requests received on RX2.