### PR TITLE
LoRaMacSerializerData buffer overflow fix

### DIFF
--- a/src/mac/LoRaMacSerializer.c
+++ b/src/mac/LoRaMacSerializer.c
@@ -134,19 +134,19 @@ LoRaMacSerializerStatus_t LoRaMacSerializerData( LoRaMacMessageData_t* macMsg )
                                + LORAMAC_FHDR_F_CTRL_FIELD_SIZE
                                + LORAMAC_FHDR_F_CNT_FIELD_SIZE;
 
-    if( macMsg->FRMPayloadSize == 0 )
+    computedBufSize += macMsg->FHDR.FCtrl.Bits.FOptsLen;
+
+    if( macMsg->FRMPayloadSize > 0 )
     {
-        if( macMsg->BufSize < computedBufSize )
-        {
-            return LORAMAC_SERIALIZER_ERROR_BUF_SIZE;
-        }
+        computedBufSize += LORAMAC_F_PORT_FIELD_SIZE;
     }
-    else
-    {   //If FRMPayload >0, FPort field is present.
-        if( macMsg->BufSize < computedBufSize + macMsg->FHDR.FCtrl.Bits.FOptsLen + macMsg->FRMPayloadSize + LORAMAC_F_PORT_FIELD_SIZE )
-        {
-            return LORAMAC_SERIALIZER_ERROR_BUF_SIZE;
-        }
+
+    computedBufSize += macMsg->FRMPayloadSize;
+    computedBufSize += LORAMAC_MIC_FIELD_SIZE;
+
+    if( macMsg->BufSize < computedBufSize )
+    {
+        return LORAMAC_SERIALIZER_ERROR_BUF_SIZE;
     }
 
     macMsg->Buffer[bufItr++] = macMsg->MHDR.Value;


### PR DESCRIPTION
A buffer size is computed and used to check the buffer size, but two flaws introduce the possibility of memory corruption:
- the MIC field is not taken into account
- the FOpts length is only taken into account when payloadsize>0, while the FOpts are always added

With this patch the correct number of bytes is calculated.
The calculation looks a bit verbose now, but for clarity it follows the exact order in which the message will be built up. Compiler optimization should combine all constants into one compound value.