### PR TITLE
Fix sx126x RadioSetTxContinuousWave wrong timer

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -968,8 +968,8 @@ void RadioSetTxContinuousWave( uint32_t freq, int8_t power, uint16_t time )
     SX126xSetRfTxPower( power );
     SX126xSetTxContinuousWave( );
 
-    TimerSetValue( &RxTimeoutTimer, time  * 1e3 );
-    TimerStart( &RxTimeoutTimer );
+    TimerSetValue( &TxTimeoutTimer, time  * 1e3 );
+    TimerStart( &TxTimeoutTimer );
 }
 
 int16_t RadioRssi( RadioModems_t modem )


### PR DESCRIPTION
Fixes RadioSetTxContinousWave for SX126x to use the TX timer, as expected, instead of the RX timer for timeout callback invocation.