### PR TITLE
Fix missing file compiler errors 

### DIFF
--- a/src/apps/LoRaMac/common/CayenneLpp.c
+++ b/src/apps/LoRaMac/common/CayenneLpp.c
@@ -20,7 +20,7 @@
  */
 #include <stdint.h>
 
-#include "Utilities.h"
+#include "utilities.h"
 #include "CayenneLpp.h"
 
 #define CAYENNE_LPP_MAXBUFFER_SIZE                  242

--- a/src/apps/LoRaMac/common/LmHandler/packages/LmhpClockSync.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/LmhpClockSync.c
@@ -19,7 +19,7 @@
  *
  * \author    Miguel Luis ( Semtech )
  */
-#include "SysTime.h"
+#include "systime.h"
 #include "LmHandler.h"
 #include "LmhpClockSync.h"
 


### PR DESCRIPTION
A couple include statements with wrong filename case, resulting in missing file compilation errors in case sensitive build environments.