### PR TITLE
Fix McClassCSessionAns payload

### DIFF
--- a/src/apps/LoRaMac/common/LmHandler/packages/LmhpRemoteMcastSetup.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/LmhpRemoteMcastSetup.c
@@ -335,7 +335,7 @@ static void LmhpRemoteMcastSetupOnMcpsIndication( McpsIndication_t *mcpsIndicati
 
                 McSessionData[id].RxParams.ClassC.Datarate = mcpsIndication->Buffer[cmdIndex++];
 
-                LmhpRemoteMcastSetupState.DataBuffer[dataBufferIndex++] = REMOTE_MCAST_SETUP_MC_GROUP_SETUP_ANS;
+                LmhpRemoteMcastSetupState.DataBuffer[dataBufferIndex++] = REMOTE_MCAST_SETUP_MC_GROUP_CLASS_C_SESSION_ANS;
                 if( LoRaMacMcChannelSetupRxParams( id, &McSessionData[id].RxParams, &status ) == LORAMAC_STATUS_OK )
                 {
                     SysTime_t curTime = { .Seconds = 0, .SubSeconds = 0 };


### PR DESCRIPTION
The serialized command was not set to the correct value; instead, it was set to the Multicast Group Setup answer command .