### PR TITLE
LoRaMacFCntHandler: changed initialization order

### DIFF
--- a/src/mac/LoRaMacFCntHandler.c
+++ b/src/mac/LoRaMacFCntHandler.c
@@ -106,11 +106,11 @@ static void NvmCtxChanged( void )
 
 LoRaMacFCntHandlerStatus_t LoRaMacFCntHandlerInit( EventNvmCtxChanged fCntHandlerNvmCtxChanged )
 {
-    // Initialize with default
-    LoRaMacResetFCnts( );
-
     // Assign callback
     FCntHandlerNvmCtxChanged = fCntHandlerNvmCtxChanged;
+
+    // Initialize with default
+    LoRaMacResetFCnts( );
 
     return LORAMAC_FCNT_HANDLER_SUCCESS;
 }


### PR DESCRIPTION
The callback is assigned after resetting FCnt values in LoRaMacResetFCnts(), while LoRaMacResetFCnts() tries to invoke the callback using NvmCtxChanged(), which will either fail (no callback has been set before) or - in theory - call a callback which has been assigned before, which seems to lead to unexpected behavior.

By reversing the statements this is fixed.