### PR TITLE
Reworked Cmac hash computation for lower memory consumption

### DIFF
--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -364,49 +364,6 @@ static LoRaMacCryptoStatus_t FOptsEncrypt( uint16_t size, uint32_t address, uint
 }
 
 /*
- * Computes cmac.
- *
- *  cmac = aes128_cmac(keyID, msg)
- *
- * \param[IN]  msg            - Message to compute the integrity code
- * \param[IN]  len            - Length of message
- * \param[IN]  keyID          - Key identifier
- * \param[OUT] cmac           - Computed cmac
- * \retval                    - Status of the operation
- */
-static LoRaMacCryptoStatus_t ComputeCmac( uint8_t* msg, uint16_t len, KeyIdentifier_t keyID, uint32_t* cmac )
-{
-    struct se_block part;
-    part.buffer = msg;
-    part.size = len;
-    if( SecureElementComputeAesCmacParts( &part, 1, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
-    {
-        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
-    }
-
-    return LORAMAC_CRYPTO_SUCCESS;
-}
-
-/*!
- * Verifies cmac
- *
- * \param[IN]  msg            - Message to compute the integrity code
- * \param[IN]  len            - Length of message
- * \param[in]  expectedCmac   - Expected cmac
- * \param[IN]  keyID          - Key identifier to determine the AES key to be used
- * \retval                    - Status of the operation
- */
-static LoRaMacCryptoStatus_t VerifyCmac( uint8_t* msg, uint16_t len, KeyIdentifier_t keyID, uint32_t expectedcmac )
-{
-    if( SecureElementVerifyAesCmac( msg, len, expectedcmac, keyID ) != SECURE_ELEMENT_SUCCESS )
-    {
-        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
-    }
-
-    return LORAMAC_CRYPTO_SUCCESS;
-}
-
-/*
  * Prepares B0 block for cmac computation.
  *
  * \param[IN]  msgLen         - Length of message
@@ -497,22 +454,37 @@ static LoRaMacCryptoStatus_t ComputeCmacB0( uint8_t* msg, uint16_t len, KeyIdent
         return LORAMAC_CRYPTO_ERROR_BUF_SIZE;
     }
 
+#if( USE_CMAC_BLOCKS_API == 0 )
+    uint8_t micBuff[CRYPTO_BUFFER_SIZE];
+    memset1( micBuff, 0, CRYPTO_BUFFER_SIZE );
+
+    // Initialize the first Block
+    PrepareB0( len, keyID, isAck, dir, devAddr, fCnt, micBuff );
+
+    // Copy the given data to the mic computation buffer
+    memcpy1( ( micBuff + MIC_BLOCK_BX_SIZE ), msg, len );
+
+    if( SecureElementComputeAesCmac( micBuff, ( len + MIC_BLOCK_BX_SIZE ), keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    {
+        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
+    }
+#else
     uint8_t micBuff[MIC_BLOCK_BX_SIZE];
 
     // Initialize the first Block
     PrepareB0( len, keyID, isAck, dir, devAddr, fCnt, micBuff );
 
-    struct se_block parts[2];
-    parts[0].buffer = micBuff;
-    parts[0].size = sizeof( micBuff );
-    parts[1].buffer = msg;
-    parts[1].size = len;
+    SecureElementBlock_t blocks[2];
+    blocks[0].Buffer = micBuff;
+    blocks[0].Size = sizeof( micBuff );
+    blocks[1].Buffer = msg;
+    blocks[1].Size = len;
 
-    if( SecureElementComputeAesCmacParts( parts, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmacBlocks( blocks, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
-
+#endif
     return LORAMAC_CRYPTO_SUCCESS;
 }
 
@@ -647,29 +619,42 @@ static LoRaMacCryptoStatus_t ComputeCmacB1( uint8_t* msg, uint16_t len, KeyIdent
         return LORAMAC_CRYPTO_ERROR_BUF_SIZE;
     }
 
+#if( USE_CMAC_BLOCKS_API == 0 )
+    uint8_t micBuff[CRYPTO_BUFFER_SIZE];
+    memset1( micBuff, 0, CRYPTO_BUFFER_SIZE );
+
+    // Initialize the first Block
+    PrepareB1( len, keyID, isAck, txDr, txCh, devAddr, fCntUp, micBuff );
+
+    // Copy the given data to the mic computation buffer
+    memcpy1( ( micBuff + MIC_BLOCK_BX_SIZE ), msg, len );
+
+    if( SecureElementComputeAesCmac( micBuff, ( len + MIC_BLOCK_BX_SIZE ), keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    {
+        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
+    }
+#else
     uint8_t micBuff[MIC_BLOCK_BX_SIZE];
 
     // Initialize the first Block
     PrepareB1( len, keyID, isAck, txDr, txCh, devAddr, fCntUp, micBuff );
 
-    struct se_block parts[2];
-    parts[0].buffer = micBuff;
-    parts[0].size = sizeof( micBuff );
-    parts[1].buffer = msg;
-    parts[1].size = len;
+    SecureElementBlock_t blocks[2];
+    blocks[0].Buffer = micBuff;
+    blocks[0].Size = sizeof( micBuff );
+    blocks[1].Buffer = msg;
+    blocks[1].Size = len;
 
-    if( SecureElementComputeAesCmacParts( parts, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmacBlocks( blocks, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
-
+#endif
     return LORAMAC_CRYPTO_SUCCESS;
 }
 
 /*
  * Gets security item from list.
- *
- *  cmac = aes128_cmac(keyID, B0 | msg)
  *
  * \param[IN]  addrID          - Address identifier
  * \param[OUT] keyItem        - Key item reference
@@ -916,7 +901,7 @@ static void UpdateFCntDown( FCntIdentifier_t fCntID, uint32_t currentDown )
 /*!
  * Resets the frame counters
  */
-void ResetFCnts( void )
+static void ResetFCnts( void )
 {
 
     CryptoCtx.NvmCtx->FCntUp = 0;
@@ -1051,10 +1036,9 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareJoinRequest( LoRaMacMessageJoinRequest
     }
 
     // Compute mic
-    retval = ComputeCmac( macMsg->Buffer, ( LORAMAC_JOIN_REQ_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, &macMsg->MIC );
-    if( retval != LORAMAC_CRYPTO_SUCCESS )
+    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_JOIN_REQ_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
-        return retval;
+        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
 
     // Reserialize message to add the MIC
@@ -1087,10 +1071,9 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareReJoinType1( LoRaMacMessageReJoinType1
 
     // Compute mic
     // cmac = aes128_cmac(JSIntKey, MHDR | RejoinType | JoinEUI| DevEUI | RJcount1)
-    LoRaMacCryptoStatus_t retval = ComputeCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_1_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), J_S_INT_KEY, &macMsg->MIC );
-    if( retval != LORAMAC_CRYPTO_SUCCESS )
+    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_1_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), J_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
-        return retval;
+        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
 
     // Reserialize message to add the MIC
@@ -1127,10 +1110,9 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareReJoinType0or2( LoRaMacMessageReJoinTy
 
     // Compute mic
     // cmac = aes128_cmac(SNwkSIntKey, MHDR | Rejoin Type | NetID | DevEUI | RJcount0)
-    LoRaMacCryptoStatus_t retval = ComputeCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_0_2_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), S_NWK_S_INT_KEY, &macMsg->MIC );
-    if( retval != LORAMAC_CRYPTO_SUCCESS )
+    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_0_2_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), S_NWK_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
-        return retval;
+        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
 
     // Reserialize message to add the MIC
@@ -1213,10 +1195,9 @@ LoRaMacCryptoStatus_t LoRaMacCryptoHandleJoinAccept( JoinReqIdentifier_t joinReq
     {
         // For legacy mode :
         //   cmac = aes128_cmac(NwkKey, MHDR |  JoinNonce | NetID | DevAddr | DLSettings | RxDelay | CFList | CFListType)
-        retval = VerifyCmac( macMsg->Buffer, ( macMsg->BufSize - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, macMsg->MIC );
-        if( retval != LORAMAC_CRYPTO_SUCCESS )
+        if( SecureElementVerifyAesCmac( macMsg->Buffer, ( macMsg->BufSize - LORAMAC_MIC_FIELD_SIZE ), macMsg->MIC, micComputationKeyID ) != SECURE_ELEMENT_SUCCESS )
         {
-            return retval;
+            return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
         }
     }
     else
@@ -1236,10 +1217,9 @@ LoRaMacCryptoStatus_t LoRaMacCryptoHandleJoinAccept( JoinReqIdentifier_t joinReq
 
         procBuffer[bufItr++] = macMsg->MHDR.Value;
 
-        retval = VerifyCmac( procBuffer, ( macMsg->BufSize + micComputationOffset - LORAMAC_MHDR_FIELD_SIZE - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, macMsg->MIC );
-        if( retval != LORAMAC_CRYPTO_SUCCESS )
+        if( SecureElementVerifyAesCmac( macMsg->Buffer,  ( macMsg->BufSize + micComputationOffset - LORAMAC_MHDR_FIELD_SIZE - LORAMAC_MIC_FIELD_SIZE ), macMsg->MIC, micComputationKeyID ) != SECURE_ELEMENT_SUCCESS )
         {
-            return retval;
+            return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
         }
 
         // Check if the JoinNonce is greater as the previous one

--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -474,13 +474,7 @@ static LoRaMacCryptoStatus_t ComputeCmacB0( uint8_t* msg, uint16_t len, KeyIdent
     // Initialize the first Block
     PrepareB0( len, keyID, isAck, dir, devAddr, fCnt, micBuff );
 
-    SecureElementBlock_t blocks[2];
-    blocks[0].Buffer = micBuff;
-    blocks[0].Size = sizeof( micBuff );
-    blocks[1].Buffer = msg;
-    blocks[1].Size = len;
-
-    if( SecureElementComputeAesCmacBlocks( blocks, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmacBlocks( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
@@ -639,13 +633,7 @@ static LoRaMacCryptoStatus_t ComputeCmacB1( uint8_t* msg, uint16_t len, KeyIdent
     // Initialize the first Block
     PrepareB1( len, keyID, isAck, txDr, txCh, devAddr, fCntUp, micBuff );
 
-    SecureElementBlock_t blocks[2];
-    blocks[0].Buffer = micBuff;
-    blocks[0].Size = sizeof( micBuff );
-    blocks[1].Buffer = msg;
-    blocks[1].Size = len;
-
-    if( SecureElementComputeAesCmacBlocks( blocks, 2, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmacBlocks( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }

--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -454,31 +454,15 @@ static LoRaMacCryptoStatus_t ComputeCmacB0( uint8_t* msg, uint16_t len, KeyIdent
         return LORAMAC_CRYPTO_ERROR_BUF_SIZE;
     }
 
-#if( USE_CMAC_BLOCKS_API == 0 )
-    uint8_t micBuff[CRYPTO_BUFFER_SIZE];
-    memset1( micBuff, 0, CRYPTO_BUFFER_SIZE );
-
-    // Initialize the first Block
-    PrepareB0( len, keyID, isAck, dir, devAddr, fCnt, micBuff );
-
-    // Copy the given data to the mic computation buffer
-    memcpy1( ( micBuff + MIC_BLOCK_BX_SIZE ), msg, len );
-
-    if( SecureElementComputeAesCmac( micBuff, ( len + MIC_BLOCK_BX_SIZE ), keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
-    {
-        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
-    }
-#else
     uint8_t micBuff[MIC_BLOCK_BX_SIZE];
 
     // Initialize the first Block
     PrepareB0( len, keyID, isAck, dir, devAddr, fCnt, micBuff );
 
-    if( SecureElementComputeAesCmacBlocks( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmac( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
-#endif
     return LORAMAC_CRYPTO_SUCCESS;
 }
 
@@ -613,31 +597,15 @@ static LoRaMacCryptoStatus_t ComputeCmacB1( uint8_t* msg, uint16_t len, KeyIdent
         return LORAMAC_CRYPTO_ERROR_BUF_SIZE;
     }
 
-#if( USE_CMAC_BLOCKS_API == 0 )
-    uint8_t micBuff[CRYPTO_BUFFER_SIZE];
-    memset1( micBuff, 0, CRYPTO_BUFFER_SIZE );
-
-    // Initialize the first Block
-    PrepareB1( len, keyID, isAck, txDr, txCh, devAddr, fCntUp, micBuff );
-
-    // Copy the given data to the mic computation buffer
-    memcpy1( ( micBuff + MIC_BLOCK_BX_SIZE ), msg, len );
-
-    if( SecureElementComputeAesCmac( micBuff, ( len + MIC_BLOCK_BX_SIZE ), keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
-    {
-        return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
-    }
-#else
     uint8_t micBuff[MIC_BLOCK_BX_SIZE];
 
     // Initialize the first Block
     PrepareB1( len, keyID, isAck, txDr, txCh, devAddr, fCntUp, micBuff );
 
-    if( SecureElementComputeAesCmacBlocks( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmac( micBuff, msg, len, keyID, cmac ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
-#endif
     return LORAMAC_CRYPTO_SUCCESS;
 }
 
@@ -1024,7 +992,7 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareJoinRequest( LoRaMacMessageJoinRequest
     }
 
     // Compute mic
-    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_JOIN_REQ_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmac( NULL, macMsg->Buffer, ( LORAMAC_JOIN_REQ_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), micComputationKeyID, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
@@ -1059,7 +1027,7 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareReJoinType1( LoRaMacMessageReJoinType1
 
     // Compute mic
     // cmac = aes128_cmac(JSIntKey, MHDR | RejoinType | JoinEUI| DevEUI | RJcount1)
-    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_1_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), J_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmac( NULL, macMsg->Buffer, ( LORAMAC_RE_JOIN_1_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), J_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }
@@ -1098,7 +1066,7 @@ LoRaMacCryptoStatus_t LoRaMacCryptoPrepareReJoinType0or2( LoRaMacMessageReJoinTy
 
     // Compute mic
     // cmac = aes128_cmac(SNwkSIntKey, MHDR | Rejoin Type | NetID | DevEUI | RJcount0)
-    if( SecureElementComputeAesCmac( macMsg->Buffer, ( LORAMAC_RE_JOIN_0_2_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), S_NWK_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
+    if( SecureElementComputeAesCmac( NULL, macMsg->Buffer, ( LORAMAC_RE_JOIN_0_2_MSG_SIZE - LORAMAC_MIC_FIELD_SIZE ), S_NWK_S_INT_KEY, &macMsg->MIC ) != SECURE_ELEMENT_SUCCESS )
     {
         return LORAMAC_CRYPTO_ERROR_SECURE_ELEMENT_FUNC;
     }

--- a/src/mac/secure-element.h
+++ b/src/mac/secure-element.h
@@ -37,6 +37,11 @@
 #include <stdint.h>
 #include "LoRaMacCrypto.h"
 
+/*
+ * When set to 1 the new SecureElementComputeAesCmacBlocks API may be used.
+ */
+#define USE_CMAC_BLOCKS_API                         1
+
 /*!
  * Return values.
  */
@@ -71,6 +76,17 @@ typedef enum eSecureElementStatus
      */
     SECURE_ELEMENT_ERROR,
 }SecureElementStatus_t;
+
+#if( USE_CMAC_BLOCKS_API == 1 )
+/*!
+ * CMAC buffer block.
+ */
+typedef struct SecureElementBlock_s
+{
+    uint8_t *Buffer;
+    uint16_t Size;
+}SecureElementBlock_t;
+#endif
 
 /*!
  * Signature of callback function to be called by the Secure Element driver when the
@@ -114,19 +130,28 @@ void* SecureElementGetNvmCtx( size_t* seNvmCtxSize );
 SecureElementStatus_t SecureElementSetKey( KeyIdentifier_t keyID, uint8_t* key );
 
 /*!
- * Computes a CMAC of a message given in parts
+ * Computes a CMAC of a message
  *
- * \param[IN]  buffers        - Data buffers
- * \param[IN]  numparts       - Number of buffers
+ * \param[IN]  buffer         - Data buffer
+ * \param[IN]  size           - Data buffer size
  * \param[IN]  keyID          - Key identifier to determine the AES key to be used
  * \param[OUT] cmac           - Computed cmac
  * \retval                    - Status of the operation
  */
-struct se_block {
-    uint8_t *buffer;
-    uint16_t size;
-};
-SecureElementStatus_t SecureElementComputeAesCmacParts( struct se_block *parts, uint16_t numparts, KeyIdentifier_t keyID, uint32_t* cmac );
+SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
+
+#if( USE_CMAC_BLOCKS_API == 1 )
+/*!
+ * Computes a CMAC of a message given in blocks
+ *
+ * \param[IN]  blocks         - Buffer blocks
+ * \param[IN]  nbBlocks       - Number of buffer blocks
+ * \param[IN]  keyID          - Key identifier to determine the AES key to be used
+ * \param[OUT] cmac           - Computed cmac
+ * \retval                    - Status of the operation
+ */
+SecureElementStatus_t SecureElementComputeAesCmacBlocks( SecureElementBlock_t* blocks, uint16_t nbBlocks, KeyIdentifier_t keyID, uint32_t* cmac );
+#endif
 
 /*!
  * Verifies a CMAC (computes and compare with expected cmac)

--- a/src/mac/secure-element.h
+++ b/src/mac/secure-element.h
@@ -77,17 +77,6 @@ typedef enum eSecureElementStatus
     SECURE_ELEMENT_ERROR,
 }SecureElementStatus_t;
 
-#if( USE_CMAC_BLOCKS_API == 1 )
-/*!
- * CMAC buffer block.
- */
-typedef struct SecureElementBlock_s
-{
-    uint8_t *Buffer;
-    uint16_t Size;
-}SecureElementBlock_t;
-#endif
-
 /*!
  * Signature of callback function to be called by the Secure Element driver when the
  * non volatile context have to be stored.
@@ -142,15 +131,16 @@ SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* buffer, uint16_t siz
 
 #if( USE_CMAC_BLOCKS_API == 1 )
 /*!
- * Computes a CMAC of a message given in blocks
+ * Computes a CMAC of a message using provided initial Bx block
  *
- * \param[IN]  blocks         - Buffer blocks
- * \param[IN]  nbBlocks       - Number of buffer blocks
+ * \param[IN]  micBxBuffer    - Buffer containing the initial Bx block
+ * \param[IN]  buffer         - Data buffer
+ * \param[IN]  size           - Data buffer size
  * \param[IN]  keyID          - Key identifier to determine the AES key to be used
  * \param[OUT] cmac           - Computed cmac
  * \retval                    - Status of the operation
  */
-SecureElementStatus_t SecureElementComputeAesCmacBlocks( SecureElementBlock_t* blocks, uint16_t nbBlocks, KeyIdentifier_t keyID, uint32_t* cmac );
+SecureElementStatus_t SecureElementComputeAesCmacBlocks( uint8_t* micBxBuffer, uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
 #endif
 
 /*!

--- a/src/mac/secure-element.h
+++ b/src/mac/secure-element.h
@@ -37,11 +37,6 @@
 #include <stdint.h>
 #include "LoRaMacCrypto.h"
 
-/*
- * When set to 1 the new SecureElementComputeAesCmacBlocks API may be used.
- */
-#define USE_CMAC_BLOCKS_API                         1
-
 /*!
  * Return values.
  */
@@ -119,18 +114,6 @@ void* SecureElementGetNvmCtx( size_t* seNvmCtxSize );
 SecureElementStatus_t SecureElementSetKey( KeyIdentifier_t keyID, uint8_t* key );
 
 /*!
- * Computes a CMAC of a message
- *
- * \param[IN]  buffer         - Data buffer
- * \param[IN]  size           - Data buffer size
- * \param[IN]  keyID          - Key identifier to determine the AES key to be used
- * \param[OUT] cmac           - Computed cmac
- * \retval                    - Status of the operation
- */
-SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
-
-#if( USE_CMAC_BLOCKS_API == 1 )
-/*!
  * Computes a CMAC of a message using provided initial Bx block
  *
  * \param[IN]  micBxBuffer    - Buffer containing the initial Bx block
@@ -140,8 +123,7 @@ SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* buffer, uint16_t siz
  * \param[OUT] cmac           - Computed cmac
  * \retval                    - Status of the operation
  */
-SecureElementStatus_t SecureElementComputeAesCmacBlocks( uint8_t* micBxBuffer, uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
-#endif
+SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* micBxBuffer, uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
 
 /*!
  * Verifies a CMAC (computes and compare with expected cmac)

--- a/src/mac/secure-element.h
+++ b/src/mac/secure-element.h
@@ -114,15 +114,19 @@ void* SecureElementGetNvmCtx( size_t* seNvmCtxSize );
 SecureElementStatus_t SecureElementSetKey( KeyIdentifier_t keyID, uint8_t* key );
 
 /*!
- * Computes a CMAC
+ * Computes a CMAC of a message given in parts
  *
- * \param[IN]  buffer         - Data buffer
- * \param[IN]  size           - Data buffer size
+ * \param[IN]  buffers        - Data buffers
+ * \param[IN]  numparts       - Number of buffers
  * \param[IN]  keyID          - Key identifier to determine the AES key to be used
  * \param[OUT] cmac           - Computed cmac
  * \retval                    - Status of the operation
  */
-SecureElementStatus_t SecureElementComputeAesCmac( uint8_t* buffer, uint16_t size, KeyIdentifier_t keyID, uint32_t* cmac );
+struct se_block {
+    uint8_t *buffer;
+    uint16_t size;
+};
+SecureElementStatus_t SecureElementComputeAesCmacParts( struct se_block *parts, uint16_t numparts, KeyIdentifier_t keyID, uint32_t* cmac );
 
 /*!
  * Verifies a CMAC (computes and compare with expected cmac)

--- a/src/peripherals/soft-se/soft-se.c
+++ b/src/peripherals/soft-se/soft-se.c
@@ -178,7 +178,7 @@ static SecureElementStatus_t ComputeCmacBlocks( uint8_t *micBxBuffer, uint8_t *b
     {
         AES_CMAC_SetKey( SeNvmCtx.AesCmacCtx, keyItem->KeyValue );
 
-        if ( micBxBuffer )
+        if( micBxBuffer != NULL )
         {
             AES_CMAC_Update( SeNvmCtx.AesCmacCtx, micBxBuffer, 16 );
         }


### PR DESCRIPTION
By allowing the Cmac hash computations to be done on a sequence of blocks, there is no need anymore to memcpy the entire message to the stack.

This lowers stack usage by >200 bytes for some frequently used code paths.