### PR TITLE
Fix Fragmentation Decoder stack buffer overrun

### DIFF
--- a/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
@@ -261,7 +261,7 @@ int32_t FragDecoderProcess( uint16_t fragCounter, uint8_t *rawData )
     uint8_t dataTempVector[( FRAG_MAX_REDUNDANCY >> 3 ) + 1];
     uint8_t dataTempVector2[( FRAG_MAX_REDUNDANCY >> 3 ) + 1];
 
-    memset1( matrixRow, 0, FRAG_MAX_NB );
+    memset1( matrixRow, 0, (FRAG_MAX_NB >> 3 ) + 1 );
     memset1( matrixDataTemp, 0, FRAG_MAX_SIZE );
     memset1( dataTempVector, 0, ( FRAG_MAX_REDUNDANCY >> 3 ) + 1 );
     memset1( dataTempVector2, 0, ( FRAG_MAX_REDUNDANCY >> 3 ) + 1 );


### PR DESCRIPTION
After raising the compiler's optimization level, I observed the fragmentation decoder state variables being corrupted sometime during the receive of the first fragment.  Root caused to stack overrun on initialization of the stack variable matrixRow by 8x its size.