### PR TITLE
Fixed PrepareB0 for Confirmed Frames

### DIFF
--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -404,19 +404,13 @@ static LoRaMacCryptoStatus_t PrepareB0( uint16_t msgLen, KeyIdentifier_t keyID, 
 
     b0[0] = 0x49;
 
-    if( isAck == true )
+    if( ( isAck == true ) && ( dir == DOWNLINK ) )
     {
         // confFCnt contains the frame counter value modulo 2^16 of the "confirmed" uplink or downlink frame that is being acknowledged
         uint16_t confFCnt = 0;
-        if( dir == UPLINK )
-        {
-            confFCnt = ( uint16_t )( CryptoCtx.NvmCtx->FCntDown % 65536 );
-        }
-        else
-        {
-            confFCnt = ( uint16_t )( CryptoCtx.NvmCtx->FCntUp % 65536 );
-        }
-
+        
+        confFCnt = ( uint16_t )( CryptoCtx.NvmCtx->FCntUp % 65536 );
+        
         b0[1] = confFCnt & 0xFF;
         b0[2] = ( confFCnt >> 8 ) & 0xFF;
     }


### PR DESCRIPTION
As per LoRaWAN1.1 Spec ConfFCnt is only used for Downlink frames for block B0. For Uplink Frames ConfFCnt is used for block B1
![image](https://user-images.githubusercontent.com/42280888/54998618-e710b580-4fce-11e9-983d-7fbee6c17ac6.png)
![image](https://user-images.githubusercontent.com/42280888/54998705-17f0ea80-4fcf-11e9-8a42-17033520b5d8.png)
