### PR TITLE
Changed location of enforcement of MAX_ACK_RETRIES to prevent infinite resubmit loop

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2971,7 +2971,7 @@ static bool StopRetransmission( void )
 
 static void AckTimeoutRetriesProcess( void )
 {
-    if( ( MacCtx.AckTimeoutRetriesCounter < MacCtx.AckTimeoutRetries ) && ( MacCtx.AckTimeoutRetriesCounter <= MAX_ACK_RETRIES ) )
+    if( MacCtx.AckTimeoutRetriesCounter < MacCtx.AckTimeoutRetries )
     {
         MacCtx.AckTimeoutRetriesCounter++;
         if( ( MacCtx.AckTimeoutRetriesCounter % 2 ) == 1 )
@@ -4399,7 +4399,7 @@ LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t* mcpsRequest )
         case MCPS_CONFIRMED:
         {
             readyToSend = true;
-            MacCtx.AckTimeoutRetries = mcpsRequest->Req.Confirmed.NbTrials;
+            MacCtx.AckTimeoutRetries = MIN( mcpsRequest->Req.Confirmed.NbTrials, MAX_ACK_RETRIES );
 
             macHdr.Bits.MType = FRAME_TYPE_DATA_CONFIRMED_UP;
             fPort = mcpsRequest->Req.Confirmed.fPort;


### PR DESCRIPTION
If more than MAX_ACK_RETRIES (8) retries were requested, the retry counter was not incremented beyond that value, making the stack retry ad infinitum.
    
By enforcing this value at the point where the number of retries is set, this is fixed.