### PR TITLE
LoRaMac: effectuate acknowledged ADR request elements

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1972,12 +1972,17 @@ static void ProcessMacCommands( uint8_t *payload, uint8_t macIndex, uint8_t comm
                     status = RegionLinkAdrReq( MacCtx.NvmCtx->Region, &linkAdrReq, &linkAdrDatarate,
                                                &linkAdrTxPower, &linkAdrNbRep, &linkAdrNbBytesParsed );
 
-                    if( ( status & 0x07 ) == 0x07 )
+                    if( status & 0x02 )
                     {
                         MacCtx.NvmCtx->MacParams.ChannelsDatarate = linkAdrDatarate;
-                        MacCtx.NvmCtx->MacParams.ChannelsTxPower = linkAdrTxPower;
-                        MacCtx.NvmCtx->MacParams.ChannelsNbTrans = linkAdrNbRep;
                     }
+
+                    if( status & 0x04 )
+                    {
+                        MacCtx.NvmCtx->MacParams.ChannelsTxPower = linkAdrTxPower;
+                    }
+
+                    MacCtx.NvmCtx->MacParams.ChannelsNbTrans = linkAdrNbRep;
 
                     // Add the answers to the buffer
                     for( uint8_t i = 0; i < ( linkAdrNbBytesParsed / 5 ); i++ )


### PR DESCRIPTION
RegionLinkAdrReq() returns a status bitmask telling whether:
0x1: the channel mask is ACK
0x2: the data rate is ACK
0x4: the txpower is ACK

The stack responds with this status mask, and should effectuate the changes it acknowledges:
- The datarate should be used if it is acknowledged; not only if all elements are (0x7) are
- The txpower should be used if it is acknowledged; ditto
- The ChannelsNbTrans can be used in all circumstances; the lorawan spec is not explicit about this, but it doesn't make sense to tie this to either of the conditions above

Before this patch it was observed that the datarate would be acknowledged to the network, but not effectuated.