### PR TITLE
RegionEU868: added band 5 to split 0.1% duty cycle bands

### DIFF
--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -127,7 +127,7 @@ static bool VerifyRfFreq( uint32_t freq, uint8_t *band )
     }
     else if( ( freq >= 868700000 ) && ( freq <= 869200000 ) )
     {
-        *band = 2;
+        *band = 5;
     }
     else if( ( freq >= 869400000 ) && ( freq <= 869650000 ) )
     {
@@ -377,6 +377,7 @@ void RegionEU868InitDefaults( InitDefaultsParams_t* params )
         EU868_BAND2,
         EU868_BAND3,
         EU868_BAND4,
+        EU868_BAND5,
     };
 
     switch( params->Type )

--- a/src/mac/region/RegionEU868.h
+++ b/src/mac/region/RegionEU868.h
@@ -229,7 +229,7 @@
 /*!
  * Maximum number of bands
  */
-#define EU868_MAX_NB_BANDS                          5
+#define EU868_MAX_NB_BANDS                          6
 
 /*!
  * Band 0 definition
@@ -260,6 +260,12 @@
  * Band = { DutyCycle, TxMaxPower, LastJoinTxDoneTime, LastTxDoneTime, TimeOff }
  */
 #define EU868_BAND4                                 { 100 , EU868_MAX_TX_POWER, 0, 0, 0 } //  1.0 %
+
+/*!
+ * Band 5 definition
+ * Band = { DutyCycle, TxMaxPower, LastJoinTxDoneTime, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND5                                 { 1000, EU868_MAX_TX_POWER, 0, 0, 0 } //  0.1 %
 
 /*!
  * LoRaMac default channel 1


### PR DESCRIPTION
Until now, band 2 is the combination of 863-865 MHz and 868.7-869.2 MHz.

There is no reason to put these two sub-bands into one logical band sharing their 0.1% dutycycle restriction. There seems to be a historical reason why these two ranges are (wrongly) put in a single band sharing the duty cycle restriction, which does not apply anymore after the appropriate standards have been clarified in recent versions.

The regional parameters document does not specify bands, but refers to ETSI EN300.220. Recent versions of EN300.220 make a clear distinction between the two ranges.

See https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_30/en_30022002v030201v.pdf (EN300.220-2 V3.2.1, 2018-04), page 22:
Band K: 863 MHz to 865 MHz, 0.1% dutycycle
Band N: 868,700 MHz to 869,200 MHz, 0.1% dutycycle

These are distinct bands.

The original confusion probably arises from CEPT/ERC/REC 70-03 (https://www.ecodocdb.dk/download/25c41779-cd6e/Rec7003e.pdf), which mentions a band (h1.2) with range 863-870 MHz and duty cycle 0.1%, with an increased duty cycle of 1% when the band use is limited to 865-868 MHz (Note 5 on page 10), which is band 0 in LoRaMac-node. This "0.1% to 1%" construction found its way to ETSI EN300.220 in older versions, see https://www.etsi.org/deliver/etsi_en/300200_300299/30022001/02.04.01_40/en_30022001v020401o.pdf, page 29 note 9: "Duty cycle may be increased to 1% if the band is limited to 865 MHz to 868 MHz."

However, the actual legal basis does not provide this "0.1% to 1%" construction, but summarizes the separate bands in EC 2017/1483 (https://eur-lex.europa.eu/eli/dec_impl/2017/1483/oj), where no connection is made between the separate 0.1% duty cycle bands. The bands defined in EC 2017/1483, that are used by LoRa, are:
```
- 46a: 863.0-865.0 MHz @ 0.1% DC (LoRaMac-node band 2)
- 47:  865.0-868.0 MHz @ 1.0% DC (LoRaMac-node band 0)
- 48:  868.0-868.6 MHz @ 1.0% DC (LoRaMac-node band 1)
- 50:  868.7-869.2 MHz @ 0.1% DC (LoRaMac-node band 5 (new in this commit))
- 54:  869.4-869.65 MHz @ 10% DC (LoRaMac-node band 3)
- 56b: 869.7-870.0 MHz @ 1.0% DC (LoRaMac-node band 4)
```

So it seems that in an attempt to summarize the legislation, a 863-870 MHz range has been introduced by Rec 70-03 or ETSI 300.220, with the most restrictive duty cycle of 0.1% of its constituent sub-bands (note that EC 2017/1483 hints at such combination in note [i] "Member States must allow adjacent frequency bands within this table to be used as a single frequency band provided the specific conditions of each of these adjacent frequency bands are met."). Although this attempt to group the 0.1% duty cycle bands (for clarity?) is maybe not wrong, the implication that their duty cycle restriction is shared, has no legal basis.