### PR TITLE
Fixed swapped RTC parameters in rt-board.c files

### DIFF
--- a/src/boards/B-L072Z-LRWAN1/rtc-board.c
+++ b/src/boards/B-L072Z-LRWAN1/rtc-board.c
@@ -185,8 +185,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/NAMote72/rtc-board.c
+++ b/src/boards/NAMote72/rtc-board.c
@@ -184,8 +184,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/NucleoL073/rtc-board.c
+++ b/src/boards/NucleoL073/rtc-board.c
@@ -185,8 +185,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/NucleoL152/rtc-board.c
+++ b/src/boards/NucleoL152/rtc-board.c
@@ -184,8 +184,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/NucleoL476/rtc-board.c
+++ b/src/boards/NucleoL476/rtc-board.c
@@ -184,8 +184,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/SKiM880B/rtc-board.c
+++ b/src/boards/SKiM880B/rtc-board.c
@@ -184,8 +184,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/SKiM881AXL/rtc-board.c
+++ b/src/boards/SKiM881AXL/rtc-board.c
@@ -185,8 +185,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)

--- a/src/boards/SKiM980A/rtc-board.c
+++ b/src/boards/SKiM980A/rtc-board.c
@@ -184,8 +184,8 @@ void RtcInit( void )
         time.Seconds                  = 0;
         time.SubSeconds               = 0;
         time.TimeFormat               = 0;
-        time.StoreOperation           = RTC_DAYLIGHTSAVING_NONE;
-        time.DayLightSaving           = RTC_STOREOPERATION_RESET;
+        time.StoreOperation           = RTC_STOREOPERATION_RESET;
+        time.DayLightSaving           = RTC_DAYLIGHTSAVING_NONE;
         HAL_RTC_SetTime( &RtcHandle, &time, RTC_FORMAT_BIN );
 
         // Enable Direct Read of the calendar registers (not through Shadow registers)


### PR DESCRIPTION
Hello.

I noticed these parameters were switched while I was trying to port the LoRaMac-node to a custom board.  However, since RTC_STOREOPERATION_RESET and RTC_DAYLIGHTSAVING_NONE are both 0, at the moment the code compiles and runs fine despite they being switched.