### PR TITLE
Fix endless cad

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -983,7 +983,7 @@ void RadioSetRxDutyCycle( uint32_t rxTime, uint32_t sleepTime )
 
 void RadioStartCad( void )
 {
-	SX126xSetDioIrqParams( IRQ_RADIO_ALL, IRQ_RADIO_ALL, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
+    SX126xSetDioIrqParams( IRQ_RADIO_ALL, IRQ_RADIO_ALL, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
     SX126xSetCad( );
 }
 

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -831,7 +831,7 @@ void RadioSetTxConfig( RadioModems_t modem, int8_t power, uint32_t fdev,
             break;
     }
 
-    // WORKAROUND - Modulation Quality with 500 kHz LoRa� Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
+    // WORKAROUND - Modulation Quality with 500 kHz LoRa® Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
     if( ( modem == MODEM_LORA ) && ( SX126x.ModulationParams.Params.LoRa.Bandwidth == LORA_BW_500 ) )
     {
         // RegTxModulation = @address 0x0889

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -831,7 +831,7 @@ void RadioSetTxConfig( RadioModems_t modem, int8_t power, uint32_t fdev,
             break;
     }
 
-    // WORKAROUND - Modulation Quality with 500 kHz LoRa® Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
+    // WORKAROUND - Modulation Quality with 500 kHz LoRaï¿½ Bandwidth, see DS_SX1261-2_V1.2 datasheet chapter 15.1
     if( ( modem == MODEM_LORA ) && ( SX126x.ModulationParams.Params.LoRa.Bandwidth == LORA_BW_500 ) )
     {
         // RegTxModulation = @address 0x0889
@@ -983,6 +983,7 @@ void RadioSetRxDutyCycle( uint32_t rxTime, uint32_t sleepTime )
 
 void RadioStartCad( void )
 {
+	SX126xSetDioIrqParams( IRQ_RADIO_ALL, IRQ_RADIO_ALL, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
     SX126xSetCad( );
 }
 

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -983,7 +983,7 @@ void RadioSetRxDutyCycle( uint32_t rxTime, uint32_t sleepTime )
 
 void RadioStartCad( void )
 {
-    SX126xSetDioIrqParams( IRQ_RADIO_ALL, IRQ_RADIO_ALL, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
+    SX126xSetDioIrqParams( IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED, IRQ_CAD_DONE | IRQ_CAD_ACTIVITY_DETECTED, IRQ_RADIO_NONE, IRQ_RADIO_NONE );
     SX126xSetCad( );
 }
 


### PR DESCRIPTION
It's possible to be trapped in a CAD if the CAD Done IRQ is masked.

It happen after a RadioSend as it allow only IRQ_TX_DONE and IRQ_RX_TX_TIMEOUT IRQs.