### PR TITLE
src: boards: Don't define MIN and MAX if already defined

### DIFF
--- a/src/boards/utilities.h
+++ b/src/boards/utilities.h
@@ -48,7 +48,9 @@ extern "C"
  * \param [IN] b 2nd value
  * \retval minValue Minimum value
  */
+#ifndef MIN
 #define MIN( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
+#endif
 
 /*!
  * \brief Returns the maximum value between a and b
@@ -57,7 +59,9 @@ extern "C"
  * \param [IN] b 2nd value
  * \retval maxValue Maximum value
  */
+#ifndef MAX
 #define MAX( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )
+#endif
 
 /*!
  * \brief Returns 2 raised to the power of n


### PR DESCRIPTION
MIN and MAX are common definitions which might be available in other
projects where loramac-node is utilised. A common example is the
Zephyr RTOS project. So, let's guard these definitions so that they
can be excluded if already available.

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>