### PR TITLE
soft-se/cmac: quick fix for misaligned 32-bit access

### DIFF
--- a/src/peripherals/soft-se/cmac.c
+++ b/src/peripherals/soft-se/cmac.c
@@ -81,7 +81,9 @@ void AES_CMAC_Update(AES_CMAC_CTX *ctx, const uint8_t *data, uint32_t len)
                             return;
                    XOR(ctx->M_last, ctx->X);
                     //rijndael_encrypt(&ctx->rijndael, ctx->X, ctx->X);
-            aes_encrypt( ctx->X, ctx->X, &ctx->rijndael);
+                    memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
+            aes_encrypt( in, in, &ctx->rijndael);
+                    memcpy1(&ctx->X[0], in, 16);
                     data += mlen;
                     len -= mlen;
             }


### PR DESCRIPTION
AES_CMAC_CTX.X is not aligned to a 32-bit boundary (offset is 91), this
is an issue when using AES with HAVE_UINT_32T support because it
requires 32-bit aligned buffers.

Fix it the same ugly way it was already done for other calls to
aes_encrypt() by copying the buffer to the stack. Proper fix is to set a
struct member alignment requirement to 32-bit by using __attribute__
((aligned (4)) but it's not portable.