### PR TITLE
Move MacStatusStrings and EventInfoStatusStrings to a common place

### DIFF
--- a/src/apps/LoRaMac/classA/B-L072Z-LRWAN1/main.c
+++ b/src/apps/LoRaMac/classA/B-L072Z-LRWAN1/main.c
@@ -235,61 +235,6 @@ extern Gpio_t Led3; // Rx
 extern Gpio_t Led4; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/NAMote72/main.c
+++ b/src/apps/LoRaMac/classA/NAMote72/main.c
@@ -238,61 +238,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/NucleoL073/main.c
+++ b/src/apps/LoRaMac/classA/NucleoL073/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/NucleoL152/main.c
+++ b/src/apps/LoRaMac/classA/NucleoL152/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/NucleoL476/main.c
+++ b/src/apps/LoRaMac/classA/NucleoL476/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/SAML21/main.c
+++ b/src/apps/LoRaMac/classA/SAML21/main.c
@@ -240,61 +240,6 @@ LoRaMacHandlerAppData_t AppData =
 extern Gpio_t Led1; // Tx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/SKiM880B/main.c
+++ b/src/apps/LoRaMac/classA/SKiM880B/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/SKiM881AXL/main.c
+++ b/src/apps/LoRaMac/classA/SKiM881AXL/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classA/SKiM980A/main.c
+++ b/src/apps/LoRaMac/classA/SKiM980A/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/B-L072Z-LRWAN1/main.c
+++ b/src/apps/LoRaMac/classB/B-L072Z-LRWAN1/main.c
@@ -264,61 +264,6 @@ extern Gpio_t Led3; // Rx
 extern Gpio_t Led4; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/NAMote72/main.c
+++ b/src/apps/LoRaMac/classB/NAMote72/main.c
@@ -261,61 +261,6 @@ extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/NucleoL073/main.c
+++ b/src/apps/LoRaMac/classB/NucleoL073/main.c
@@ -257,61 +257,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/NucleoL152/main.c
+++ b/src/apps/LoRaMac/classB/NucleoL152/main.c
@@ -257,61 +257,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/NucleoL476/main.c
+++ b/src/apps/LoRaMac/classB/NucleoL476/main.c
@@ -257,61 +257,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/SAML21/main.c
+++ b/src/apps/LoRaMac/classB/SAML21/main.c
@@ -263,61 +263,6 @@ LoRaMacHandlerAppData_t AppData =
 extern Gpio_t Led1; // Tx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/SKiM880B/main.c
+++ b/src/apps/LoRaMac/classB/SKiM880B/main.c
@@ -260,61 +260,6 @@ extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/SKiM881AXL/main.c
+++ b/src/apps/LoRaMac/classB/SKiM881AXL/main.c
@@ -260,61 +260,6 @@ extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classB/SKiM980A/main.c
+++ b/src/apps/LoRaMac/classB/SKiM980A/main.c
@@ -260,61 +260,6 @@ extern Gpio_t Led2; // Rx and blinks every 5 seconds when beacon is acquired
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/B-L072Z-LRWAN1/main.c
+++ b/src/apps/LoRaMac/classC/B-L072Z-LRWAN1/main.c
@@ -235,61 +235,6 @@ extern Gpio_t Led3; // Rx
 extern Gpio_t Led4; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/NAMote72/main.c
+++ b/src/apps/LoRaMac/classC/NAMote72/main.c
@@ -238,61 +238,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/NucleoL073/main.c
+++ b/src/apps/LoRaMac/classC/NucleoL073/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/NucleoL152/main.c
+++ b/src/apps/LoRaMac/classC/NucleoL152/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/NucleoL476/main.c
+++ b/src/apps/LoRaMac/classC/NucleoL476/main.c
@@ -234,61 +234,6 @@ extern Gpio_t Led1; // Tx
 extern Gpio_t Led2; // Rx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/SAML21/main.c
+++ b/src/apps/LoRaMac/classC/SAML21/main.c
@@ -240,61 +240,6 @@ LoRaMacHandlerAppData_t AppData =
 extern Gpio_t Led1; // Tx
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/SKiM880B/main.c
+++ b/src/apps/LoRaMac/classC/SKiM880B/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/SKiM881AXL/main.c
+++ b/src/apps/LoRaMac/classC/SKiM881AXL/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/apps/LoRaMac/classC/SKiM980A/main.c
+++ b/src/apps/LoRaMac/classC/SKiM980A/main.c
@@ -237,61 +237,6 @@ extern Gpio_t Led2; // Rx
 extern Gpio_t Led3; // App
 
 /*!
- * MAC status strings
- */
-const char* MacStatusStrings[] =
-{
-    "OK",                            // LORAMAC_STATUS_OK
-    "Busy",                          // LORAMAC_STATUS_BUSY
-    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
-    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
-    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
-    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
-    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
-    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
-    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
-    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
-    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
-    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
-    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
-    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
-    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
-    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
-    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
-    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
-    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
-    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
-    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
-    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
-    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
-    "Unknown error",                 // LORAMAC_STATUS_ERROR
-};
-
-/*!
- * MAC event info status strings.
- */
-const char* EventInfoStatusStrings[] =
-{ 
-    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
-    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
-    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
-    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
-    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
-    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
-    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
-    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
-    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
-    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
-    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
-    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
-    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
-    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
-    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
-    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
-    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
-};
-
-/*!
  * Prints the provided buffer in HEX
  * 
  * \param buffer Buffer to be printed

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -2399,6 +2399,60 @@ typedef struct sLoRaMacCallback
     void ( *MacProcessNotify )( void );
 }LoRaMacCallback_t;
 
+/*!
+ * MAC status strings
+ */
+const char* MacStatusStrings[] =
+{
+    "OK",                            // LORAMAC_STATUS_OK
+    "Busy",                          // LORAMAC_STATUS_BUSY
+    "Service unknown",               // LORAMAC_STATUS_SERVICE_UNKNOWN
+    "Parameter invalid",             // LORAMAC_STATUS_PARAMETER_INVALID
+    "Frequency invalid",             // LORAMAC_STATUS_FREQUENCY_INVALID
+    "Datarate invalid",              // LORAMAC_STATUS_DATARATE_INVALID
+    "Frequency or datarate invalid", // LORAMAC_STATUS_FREQ_AND_DR_INVALID
+    "No network joined",             // LORAMAC_STATUS_NO_NETWORK_JOINED
+    "Length error",                  // LORAMAC_STATUS_LENGTH_ERROR
+    "Region not supported",          // LORAMAC_STATUS_REGION_NOT_SUPPORTED
+    "Skipped APP data",              // LORAMAC_STATUS_SKIPPED_APP_DATA
+    "Duty-cycle restricted",         // LORAMAC_STATUS_DUTYCYCLE_RESTRICTED
+    "No channel found",              // LORAMAC_STATUS_NO_CHANNEL_FOUND
+    "No free channel found",         // LORAMAC_STATUS_NO_FREE_CHANNEL_FOUND
+    "Busy beacon reserved time",     // LORAMAC_STATUS_BUSY_BEACON_RESERVED_TIME
+    "Busy ping-slot window time",    // LORAMAC_STATUS_BUSY_PING_SLOT_WINDOW_TIME
+    "Busy uplink collision",         // LORAMAC_STATUS_BUSY_UPLINK_COLLISION
+    "Crypto error",                  // LORAMAC_STATUS_CRYPTO_ERROR
+    "FCnt handler error",            // LORAMAC_STATUS_FCNT_HANDLER_ERROR
+    "MAC command error",             // LORAMAC_STATUS_MAC_COMMAD_ERROR
+    "ClassB error",                  // LORAMAC_STATUS_CLASS_B_ERROR
+    "Confirm queue error",           // LORAMAC_STATUS_CONFIRM_QUEUE_ERROR
+    "Multicast group undefined",     // LORAMAC_STATUS_MC_GROUP_UNDEFINED
+    "Unknown error",                 // LORAMAC_STATUS_ERROR
+};
+
+/*!
+ * MAC event info status strings.
+ */
+const char* EventInfoStatusStrings[] =
+{ 
+    "OK",                            // LORAMAC_EVENT_INFO_STATUS_OK
+    "Error",                         // LORAMAC_EVENT_INFO_STATUS_ERROR
+    "Tx timeout",                    // LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT
+    "Rx 1 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT
+    "Rx 2 timeout",                  // LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT
+    "Rx1 error",                     // LORAMAC_EVENT_INFO_STATUS_RX1_ERROR
+    "Rx2 error",                     // LORAMAC_EVENT_INFO_STATUS_RX2_ERROR
+    "Join failed",                   // LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL
+    "Downlink repeated",             // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED
+    "Tx DR payload size error",      // LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR
+    "Downlink too many frames loss", // LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS
+    "Address fail",                  // LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL
+    "MIC fail",                      // LORAMAC_EVENT_INFO_STATUS_MIC_FAIL
+    "Multicast fail",                // LORAMAC_EVENT_INFO_STATUS_MULTICAST_FAIL
+    "Beacon locked",                 // LORAMAC_EVENT_INFO_STATUS_BEACON_LOCKED
+    "Beacon lost",                   // LORAMAC_EVENT_INFO_STATUS_BEACON_LOST
+    "Beacon not found"               // LORAMAC_EVENT_INFO_STATUS_BEACON_NOT_FOUND
+};
 
 /*!
  * LoRaMAC Max EIRP (dBm) table


### PR DESCRIPTION
Since these arrays are used throughout all platforms, it makes sense
to move it to a common place (LoRaMac.h) to avoid code duplication.

Still there is one more place where these arrays are defined,
"LoRaMac/common/LmHandlerMsgDisplay.c" but I've left it since LoRaMac.h
is not included in that file.

While moving these, I can also reuse these arrays in Zephyr LoRaWAN port.

Signed-off-by: Manivannan Sadhasivam <mani@kernel.org>