### PR TITLE
AES Crypto Abstraction

### DIFF
--- a/src/mac/secure-element.h
+++ b/src/mac/secure-element.h
@@ -231,6 +231,25 @@ SecureElementStatus_t SecureElementSetJoinEui( uint8_t* joinEui );
  */
 uint8_t* SecureElementGetJoinEui( void );
 
+/*!
+ * Initialization of AES driver
+ */
+extern void LORAMAC_AESStart(void);
+/*!
+ * De-initialization/Cleanup of AES driver
+ */
+extern void LORAMAC_AESStop(void);
+
+/*!
+ * Process AES encryption of a block of memory using with 128 bits key
+ * \param[OUT]	encBuffer		Encrypted output buffer
+ * \param[IN] 	buffer			Input buffer to encrypt
+ * \param[IN] 	size			Size of buffer to encrypt
+ * \param[IN] 	key				AES Key used to encrypt (NULL to continue with current key context for CBC)
+ * \param[IN] 	iv				Initialization Vector to XOR with input buffer before first round (for CBC)
+ */
+extern void LORAMAC_AES_128bits(uint8_t *encBuffer, const uint8_t *buffer, uint16_t size, const uint8_t *key, const uint8_t *iv );
+
 /*! \} defgroup SECUREELEMENT */
 
 #ifdef __cplusplus


### PR DESCRIPTION
This modification defines only 3 common functions for AES encryption, so that an external hardware crypto engine can be used in place of the standard software one.
By defining the external calls to:

* LORAMAC_AESStart() to perform any crypto engine startup initialisation (if needed)
* LORAMAC_AESStop() to perform any crypto engine cleanup (if needed)
* LORAMAC_AES_128bits to perform the AES encryption itself.