### PR TITLE
Fix SX126xSetLoRaSymbNumTimeout() not working issue

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -682,8 +682,7 @@ void RadioSetRxConfig( RadioModems_t modem, uint32_t bandwidth,
             break;
 
         case MODEM_LORA:
-            SX126xSetStopRxTimerOnPreambleDetect( false );
-            SX126xSetLoRaSymbNumTimeout( symbTimeout );
+            SX126xSetStopRxTimerOnPreambleDetect( false );            
             SX126x.ModulationParams.PacketType = PACKET_TYPE_LORA;
             SX126x.ModulationParams.Params.LoRa.SpreadingFactor = ( RadioLoRaSpreadingFactors_t )datarate;
             SX126x.ModulationParams.Params.LoRa.Bandwidth = Bandwidths[bandwidth];
@@ -728,6 +727,7 @@ void RadioSetRxConfig( RadioModems_t modem, uint32_t bandwidth,
             RadioSetModem( ( SX126x.ModulationParams.PacketType == PACKET_TYPE_GFSK ) ? MODEM_FSK : MODEM_LORA );
             SX126xSetModulationParams( &SX126x.ModulationParams );
             SX126xSetPacketParams( &SX126x.PacketParams );
+            SX126xSetLoRaSymbNumTimeout( symbTimeout );
 
             // WORKAROUND - Optimizing the Inverted IQ Operation, see DS_SX1261-2_V1.2 datasheet chapter 15.4
             if( SX126x.PacketParams.Params.LoRa.InvertIQ == LORA_IQ_INVERTED )


### PR DESCRIPTION
The SX126xSetLoRaSymbNumTimeout(...) function should be placed **after** RadioSetModem(...) function, because the RadioSetModem(...) function will reset the REG_LR_SYNCH_TIMEOUT(0x0706) regitster value.
