### PR TITLE
fixed the problem of receiving failure in Rx Continuous Mode

### DIFF
--- a/src/radio/sx126x/sx126x.c
+++ b/src/radio/sx126x/sx126x.c
@@ -368,7 +368,10 @@ void SX126xSetLoRaSymbNumTimeout( uint8_t SymbNum )
     }
 
     reg = exp + ( mant << 3 );
-    SX126xWriteRegister( REG_LR_SYNCH_TIMEOUT, reg );
+    if( reg != 0 )
+    {
+        SX126xWriteRegister( REG_LR_SYNCH_TIMEOUT, reg );
+    }
 }
 
 void SX126xSetRegulatorMode( RadioRegulatorMode_t mode )


### PR DESCRIPTION
fixed issue: if set REG_LR_SYNCH_TIMEOUT to 0, the chip can not receive any packet in Rx continuous mode( used by Class C).