### PR TITLE
Update sx1272.c

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -1611,7 +1611,7 @@ void SX1272OnDio2Irq( void* context )
                     SX1272.Settings.FskPacketHandler.PreambleDetected = true;
                 }
 
-                if( ( SX1272.Settings.FskPacketHandler.PreambleDetected == true ) && ( SX1272.Settings.FskPacketHandler.SyncWordDetected == false ) )
+                if( ( SX1272.Settings.FskPacketHandler.PreambleDetected != 0 ) && ( SX1272.Settings.FskPacketHandler.SyncWordDetected == 0 ) )
                 {
                     TimerStop( &RxTimeoutSyncWord );
 


### PR DESCRIPTION
Remove IAR C++ Compiler warning
Warning[Pa118]: mixing boolean and non-boolean types in a comparison results in the boolean being promoted