### PR TITLE
Fix join lrwan 1 1

### DIFF
--- a/src/boards/B-L072Z-LRWAN1/i2c-board.c
+++ b/src/boards/B-L072Z-LRWAN1/i2c-board.c
@@ -45,8 +45,8 @@ void I2cMcuInit( I2c_t *obj, I2cId_t i2cId, PinNames scl, PinNames sda )
 
     I2cHandle.Instance  = ( I2C_TypeDef * )I2C1_BASE;
 
-    GpioInit( &obj->Scl, scl, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF1_I2C1 );
-    GpioInit( &obj->Sda, sda, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF1_I2C1 );
+    GpioInit( &obj->Scl, scl, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF4_I2C1 );
+    GpioInit( &obj->Sda, sda, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF4_I2C1 );
 }
 
 void I2cMcuFormat( I2c_t *obj, I2cMode mode, I2cDutyCycle dutyCycle, bool I2cAckEnable, I2cAckAddrMode AckAddrMode, uint32_t I2cFrequency )
@@ -82,8 +82,8 @@ void I2cMcuResetBus( I2c_t *obj )
     __HAL_RCC_I2C1_FORCE_RESET( );
     __HAL_RCC_I2C1_RELEASE_RESET( );
 
-    GpioInit( &obj->Scl, I2C_SCL, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF1_I2C1 );
-    GpioInit( &obj->Sda, I2C_SDA, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF1_I2C1 );
+    GpioInit( &obj->Scl, I2C_SCL, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF4_I2C1 );
+    GpioInit( &obj->Sda, I2C_SDA, PIN_ALTERNATE_FCT, PIN_OPEN_DRAIN, PIN_NO_PULL, GPIO_AF4_I2C1 );
 
     I2cMcuFormat( obj, MODE_I2C, I2C_DUTY_CYCLE_2, true, I2C_ACK_ADD_7_BIT, 400000 );
 }

--- a/src/mac/LoRaMacCrypto.c
+++ b/src/mac/LoRaMacCrypto.c
@@ -1223,7 +1223,7 @@ LoRaMacCryptoStatus_t LoRaMacCryptoHandleJoinAccept( JoinReqIdentifier_t joinReq
     LoRaMacCryptoStatus_t retval = LORAMAC_CRYPTO_ERROR;
     uint8_t decJoinAccept[LORAMAC_JOIN_ACCEPT_FRAME_MAX_SIZE] = { 0 };
     uint8_t versionMinor         = 0;
-    uint8_t* nonce               = ( uint8_t* )&CryptoCtx.NvmCtx->DevNonce;
+    uint16_t* nonce               = ( uint16_t* )&CryptoCtx.NvmCtx->DevNonce;
 
     // Nonce selection depending on JoinReqType
     // JOIN_REQ     : CryptoCtx.NvmCtx->DevNonce


### PR DESCRIPTION
SecureElementProcessJoinAccept  fails when USE_LRWAN_1_1_X_CRYPTO == 1, as DevNonce is passed as uint8_t