### PR TITLE
Make LmHandler more C++ friendly

### DIFF
--- a/src/apps/LoRaMac/common/LmHandler/LmHandler.c
+++ b/src/apps/LoRaMac/common/LmHandler/LmHandler.c
@@ -963,7 +963,7 @@ static void LmHandlerPackagesNotify( PackageNotifyTypes_t notifyType, void *para
                 {
                     if( LmHandlerPackages[i]->OnMcpsConfirmProcess != NULL )
                     {
-                        LmHandlerPackages[i]->OnMcpsConfirmProcess( params );
+                        LmHandlerPackages[i]->OnMcpsConfirmProcess( ( sMcpsConfirm* ) params );
                     }
                     break;
                 }
@@ -972,7 +972,7 @@ static void LmHandlerPackagesNotify( PackageNotifyTypes_t notifyType, void *para
                     if( ( LmHandlerPackages[i]->OnMcpsIndicationProcess != NULL ) &&
                         ( LmHandlerPackages[i]->Port == ( ( McpsIndication_t* )params )->Port ) )
                     {
-                        LmHandlerPackages[i]->OnMcpsIndicationProcess( params );
+                        LmHandlerPackages[i]->OnMcpsIndicationProcess( ( McpsIndication_t* )params );
                     }
                     break;
                 }
@@ -980,7 +980,7 @@ static void LmHandlerPackagesNotify( PackageNotifyTypes_t notifyType, void *para
                 {
                     if( LmHandlerPackages[i]->OnMlmeConfirmProcess != NULL )
                     {
-                        LmHandlerPackages[i]->OnMlmeConfirmProcess( params );
+                        LmHandlerPackages[i]->OnMlmeConfirmProcess( ( sMlmeConfirm* )params );
                     }
                     break;
                 }

--- a/src/apps/LoRaMac/common/LmHandler/LmHandler.c
+++ b/src/apps/LoRaMac/common/LmHandler/LmHandler.c
@@ -963,7 +963,7 @@ static void LmHandlerPackagesNotify( PackageNotifyTypes_t notifyType, void *para
                 {
                     if( LmHandlerPackages[i]->OnMcpsConfirmProcess != NULL )
                     {
-                        LmHandlerPackages[i]->OnMcpsConfirmProcess( ( sMcpsConfirm* ) params );
+                        LmHandlerPackages[i]->OnMcpsConfirmProcess( ( McpsConfirm_t* ) params );
                     }
                     break;
                 }
@@ -980,7 +980,7 @@ static void LmHandlerPackagesNotify( PackageNotifyTypes_t notifyType, void *para
                 {
                     if( LmHandlerPackages[i]->OnMlmeConfirmProcess != NULL )
                     {
-                        LmHandlerPackages[i]->OnMlmeConfirmProcess( ( sMlmeConfirm* )params );
+                        LmHandlerPackages[i]->OnMlmeConfirmProcess( ( MlmeConfirm_t* )params );
                     }
                     break;
                 }


### PR DESCRIPTION
C++ disallows implicit casts from (void*) to any (some_type*). This just won't compile. So casting should be explicit.