### PR TITLE
Make gpio-board.c more C++ friendly

### DIFF
--- a/src/boards/SKiM880B/gpio-board.c
+++ b/src/boards/SKiM880B/gpio-board.c
@@ -331,6 +331,10 @@ uint32_t GpioMcuRead( Gpio_t *obj )
     }
 }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+    
 void EXTI0_IRQHandler( void )
 {
     HAL_GPIO_EXTI_IRQHandler( GPIO_PIN_0 );
@@ -374,6 +378,10 @@ void EXTI15_10_IRQHandler( void )
     HAL_GPIO_EXTI_IRQHandler( GPIO_PIN_14 );
     HAL_GPIO_EXTI_IRQHandler( GPIO_PIN_15 );
 }
+    
+#ifdef __cplusplus
+}
+#endif
 
 void HAL_GPIO_EXTI_Callback( uint16_t gpioPin )
 {


### PR DESCRIPTION
Interrupt handlers should be wrapped in extern "C" to be C++ friendly or they wont't simply be called if compiled with c++