### PR TITLE
Fixed wrong word addresses for I2C transmissions to ATECC608A

### DIFF
--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
@@ -178,7 +178,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata, uint16_t *rxlength
     int retries = iface->mIfaceCFG->rx_retries;
     while (--retries > 0 && r != 1)
     {
-        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0x3, lengthPackage, 1);
+        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0, lengthPackage, 1);
     }
 
     if (r != 1)
@@ -201,7 +201,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata, uint16_t *rxlength
     retries = iface->mIfaceCFG->rx_retries;
     while (--retries > 0 && r != 1)
     {
-        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0x3, rxdata, bytesToRead);
+        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0, rxdata, bytesToRead);
     }
 
     if (r != 1)

--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
@@ -150,8 +150,7 @@ ATCA_STATUS hal_i2c_send(ATCAIface iface, uint8_t *txdata, int txlength)
 {
 
     txdata[0] = 0x3;
-    txlength++;
-    if (I2cMcuWriteBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0, txdata, (size_t)txlength) == 1)
+    if (I2cMcuWriteBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0x3, txdata+1, (size_t)txlength) == 1)
     {
         return ATCA_SUCCESS;
     }
@@ -179,7 +178,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata, uint16_t *rxlength
     int retries = iface->mIfaceCFG->rx_retries;
     while (--retries > 0 && r != 1)
     {
-        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0, lengthPackage, 1);
+        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0x3, lengthPackage, 1);
     }
 
     if (r != 1)
@@ -187,7 +186,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata, uint16_t *rxlength
         return ATCA_RX_TIMEOUT;
     }
 
-    uint8_t bytesToRead = lengthPackage[0] - 1;
+    uint8_t bytesToRead = lengthPackage[0];
 
     if (bytesToRead > *rxlength)
     {
@@ -202,7 +201,7 @@ ATCA_STATUS hal_i2c_receive(ATCAIface iface, uint8_t *rxdata, uint16_t *rxlength
     retries = iface->mIfaceCFG->rx_retries;
     while (--retries > 0 && r != 1)
     {
-        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0, rxdata + 1, bytesToRead);
+        r = I2cMcuReadBuffer((I2c_t *)NULL, iface->mIfaceCFG->atcai2c.slave_address, 0x3, rxdata, bytesToRead);
     }
 
     if (r != 1)
@@ -272,7 +271,7 @@ ATCA_STATUS hal_i2c_wake(ATCAIface iface)
 ATCA_STATUS hal_i2c_idle(ATCAIface iface)
 {
     uint8_t buffer[1] = { 0x2 }; // idle word address value 
-    I2cMcuWriteBuffer((I2c_t*)NULL, iface->mIfaceCFG->atcai2c.slave_address,0, buffer, (size_t)1); 
+    I2cMcuWriteBuffer((I2c_t*)NULL, iface->mIfaceCFG->atcai2c.slave_address,0x2, buffer, (size_t)1);
     return ATCA_SUCCESS;
 }
 
@@ -284,7 +283,7 @@ ATCA_STATUS hal_i2c_idle(ATCAIface iface)
 ATCA_STATUS hal_i2c_sleep(ATCAIface iface)
 {
     uint8_t buffer[1] = { 0x1 };  // sleep word address value 
-    I2cMcuWriteBuffer((I2c_t*)NULL, iface->mIfaceCFG->atcai2c.slave_address,0, buffer, (size_t)1); 
+    I2cMcuWriteBuffer((I2c_t*)NULL, iface->mIfaceCFG->atcai2c.slave_address,0x1, buffer, (size_t)1);
     return ATCA_SUCCESS;
 }
 


### PR DESCRIPTION
The secure element ATECC608A-TNGLoRaWAN defines a specific I2C transmission protocol, described in the [datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/40002154A.pdf). Each individual I2C transmission must correspond to the following sequence of bytes / transmission components:

- Start condition
- Devices Address Byte
- Word Address Byte
- Optional Data Bytes
- Stop Condition

While the word address tells the secure element which operation want to be executed:

- Reset = 0x00
- Sleep = 0x01
- Idle = 0x02
- Command = 0x03

Now the existing code sent each transmission to word address 0x0, resetting the device on each transmission. It makes no sense to set the value of the word address to the first position of the tx buffer and then send it to address 0x0. Instead, I changed the code accordingly to use the correct word addresses for the different operations.