### PR TITLE
ATECC608A initialization is only possible with delays

### DIFF
--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se.c
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se.c
@@ -314,11 +314,13 @@ SecureElementStatus_t SecureElementInit( SecureElementNvmEvent seNvmCtxChanged )
         return SECURE_ELEMENT_ERROR;
     }
 
+    atca_delay_us(1500000);
     if( atcab_read_devEUI( SeNvmCtx.DevEui ) != ATCA_SUCCESS )
     {
         return SECURE_ELEMENT_ERROR;
     }
 
+    atca_delay_us(1500000);
     if( atcab_read_joinEUI( SeNvmCtx.JoinEui ) != ATCA_SUCCESS )
     {
         return SECURE_ELEMENT_ERROR;


### PR DESCRIPTION
In my case, it's not possible to initialize the secure element successfully without these delays.