### PR TITLE
Get rid of floating-point arithmetic in sx1272.c

### DIFF
--- a/src/radio/sx1272/sx1272.h
+++ b/src/radio/sx1272/sx1272.h
@@ -159,7 +159,9 @@ typedef void ( DioIrqHandler )( void* context );
  */
 #define XTAL_FREQ                                   32000000
 #define FREQ_STEP                                   61.03515625
-
+#define FREQ_CONVERT								524288
+#define HERTZ_TO_FRF_REG(f)							((((uint64_t) f) * FREQ_CONVERT) / XTAL_FREQ)
+    
 #define RX_BUFFER_SIZE                              256
 
 /*!


### PR DESCRIPTION
Introduced macro in sx1272.h to calculate FRF register
```
#define XTAL_FREQ                                 32000000
#define FREQ_CONVERT				524288
#define HERTZ_TO_FRF_REG(f)		((((uint64_t) f) * FREQ_CONVERT) / XTAL_FREQ)
```
Got rid of all double calculations in sx1272.c

```
Module                         ro code  ro data  rw data
before:    sx1272.o       4 388      366      676
after:    sx1272.o          4 232      367      676
```

This is floating point arithmetic modules used by IAR compiler. They are all gone.
```
m7M_tl.a: [4]
    DblDiv.o                    582
    DblMul.o                    418
    DblToS32.o                   58
    DblToU32.o                   40
    S32ToDbl.o                   34
    U32ToDbl.o                   26
```
This improvement helped to reduce firmware size for 1300 bytes
