### PR TITLE
Fix "implicit conversion from floating point to integer" warning

### DIFF
--- a/src/apps/LoRaMac/common/CayenneLpp.c
+++ b/src/apps/LoRaMac/common/CayenneLpp.c
@@ -90,7 +90,7 @@ uint8_t CayenneLppAddAnalogInput( uint8_t channel, float value )
         return 0;
     }
 
-    int16_t val = value * 100;
+    int16_t val = ( int16_t ) ( value * 100 );
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_ANALOG_INPUT; 
     CayenneLppBuffer[CayenneLppCursor++] = val >> 8; 
@@ -105,7 +105,7 @@ uint8_t CayenneLppAddAnalogOutput( uint8_t channel, float value )
     {
         return 0;
     }
-    int16_t val = value * 100;
+    int16_t val = ( int16_t ) ( value * 100 );
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_ANALOG_OUTPUT;
     CayenneLppBuffer[CayenneLppCursor++] = val >> 8; 
@@ -148,7 +148,7 @@ uint8_t CayenneLppAddTemperature( uint8_t channel, float celsius )
     {
         return 0;
     }
-    int16_t val = celsius * 10;
+    int16_t val = ( int16_t) ( celsius * 10 );
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_TEMPERATURE; 
     CayenneLppBuffer[CayenneLppCursor++] = val >> 8; 
@@ -165,7 +165,7 @@ uint8_t CayenneLppAddRelativeHumidity( uint8_t channel, float rh )
     }
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_RELATIVE_HUMIDITY; 
-    CayenneLppBuffer[CayenneLppCursor++] = rh * 2; 
+    CayenneLppBuffer[CayenneLppCursor++] = (uint8_t ) ( rh * 2 ); 
 
     return CayenneLppCursor;
 }
@@ -176,9 +176,9 @@ uint8_t CayenneLppAddAccelerometer( uint8_t channel, float x, float y, float z )
     {
         return 0;
     }
-    int16_t vx = x * 1000;
-    int16_t vy = y * 1000;
-    int16_t vz = z * 1000;
+    int16_t vx = ( int16_t ) ( x * 1000 );
+    int16_t vy = ( int16_t ) ( y * 1000 );
+    int16_t vz = ( int16_t ) ( z * 1000 );
 
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_ACCELEROMETER; 
@@ -198,7 +198,7 @@ uint8_t CayenneLppAddBarometricPressure( uint8_t channel, float hpa )
     {
         return 0;
     }
-    int16_t val = hpa * 10;
+    int16_t val = ( int16_t ) ( hpa * 10 );
 
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_BAROMETRIC_PRESSURE; 
@@ -214,9 +214,9 @@ uint8_t CayenneLppAddGyrometer( uint8_t channel, float x, float y, float z )
     {
         return 0;
     }
-    int16_t vx = x * 100;
-    int16_t vy = y * 100;
-    int16_t vz = z * 100;
+    int16_t vx = ( int16_t ) ( x * 100 );
+    int16_t vy = ( int16_t ) ( y * 100 );
+    int16_t vz = ( int16_t ) ( z * 100 );
 
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_GYROMETER; 
@@ -236,9 +236,9 @@ uint8_t CayenneLppAddGps( uint8_t channel, float latitude, float longitude, floa
     {
         return 0;
     }
-    int32_t lat = latitude * 10000;
-    int32_t lon = longitude * 10000;
-    int32_t alt = meters * 100;
+    int32_t lat = ( int32_t ) ( latitude * 10000 );
+    int32_t lon = ( int32_t ) ( longitude * 10000 );
+    int32_t alt = ( int32_t ) ( meters * 100 );
 
     CayenneLppBuffer[CayenneLppCursor++] = channel; 
     CayenneLppBuffer[CayenneLppCursor++] = LPP_GPS; 


### PR DESCRIPTION
Fix "implicit conversion from floating point to integer" warning
IAR C compiler issues this warning when float si converted to integer implicitly
Styling conventions applied