### PR TITLE
docs: fix simple typo, subbstited -> substituted

### DIFF
--- a/src/boards/mcu/stm32/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc_ex.h
+++ b/src/boards/mcu/stm32/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc_ex.h
@@ -358,7 +358,7 @@ typedef struct
 #define RTC_SMOOTHCALIB_PLUSPULSES_SET    RTC_CALR_CALP            /*!< The number of RTCCLK pulses added
                                                                         during a X -second window = Y - CALM[8:0]
                                                                         with Y = 512, 256, 128 when X = 32, 16, 8 */
-#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000U)   /*!< The number of RTCCLK pulses subbstited
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  ((uint32_t)0x00000000U)   /*!< The number of RTCCLK pulses substituted
                                                                         during a 32-second window = CALM[8:0] */
 
 /**

--- a/src/boards/mcu/stm32/STM32L1xx_HAL_Driver/Inc/stm32l1xx_hal_rtc_ex.h
+++ b/src/boards/mcu/stm32/STM32L1xx_HAL_Driver/Inc/stm32l1xx_hal_rtc_ex.h
@@ -516,7 +516,7 @@ typedef struct
 #define RTC_SMOOTHCALIB_PLUSPULSES_SET    (0x00008000U) /*!<  The number of RTCCLK pulses added
                                                                        during a X -second window = Y - CALM[8:0]
                                                                        with Y = 512, 256, 128 when X = 32, 16, 8 */
-#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  (0x00000000U) /*!<  The number of RTCCLK pulses subbstited
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  (0x00000000U) /*!<  The number of RTCCLK pulses substituted
                                                                        during a 32-second window =   CALM[8:0] */
 
 #define IS_RTC_SMOOTH_CALIB_PLUS(PLUS) (((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \

--- a/src/boards/mcu/stm32/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_rtc_ex.h
+++ b/src/boards/mcu/stm32/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_rtc_ex.h
@@ -168,7 +168,7 @@ typedef struct
 #define RTC_SMOOTHCALIB_PLUSPULSES_SET    RTC_CALR_CALP         /*!< The number of RTCCLK pulses added
                                                                      during a X -second window = Y - CALM[8:0]
                                                                      with Y = 512, 256, 128 when X = 32, 16, 8 */
-#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  0x00000000u           /*!< The number of RTCCLK pulses subbstited
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  0x00000000u           /*!< The number of RTCCLK pulses substituted
                                                                      during a 32-second window = CALM[8:0] */
 /**
   * @}


### PR DESCRIPTION
There is a small typo in src/boards/mcu/stm32/STM32L0xx_HAL_Driver/Inc/stm32l0xx_hal_rtc_ex.h, src/boards/mcu/stm32/STM32L1xx_HAL_Driver/Inc/stm32l1xx_hal_rtc_ex.h, src/boards/mcu/stm32/STM32L4xx_HAL_Driver/Inc/stm32l4xx_hal_rtc_ex.h.

Should read `substituted` rather than `subbstited`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md