### PR TITLE
LoRaMac: query minimum tx datarate

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3615,6 +3615,15 @@ LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t* mibGet )
             mibGet->Param.JoinAcceptDelay2 = Nvm.MacGroup2.MacParams.JoinAcceptDelay2;
             break;
         }
+        case MIB_CHANNELS_MIN_TX_DATARATE:
+        {
+            getPhy.Attribute = PHY_MIN_TX_DR;
+            getPhy.UplinkDwellTime = Nvm.MacGroup2.MacParams.UplinkDwellTime;
+            phyParam = RegionGetPhyParam( Nvm.MacGroup2.Region, &getPhy );
+
+            mibGet->Param.ChannelsMinTxDatarate = phyParam.Value;
+            break;
+        }
         case MIB_CHANNELS_DEFAULT_DATARATE:
         {
             mibGet->Param.ChannelsDefaultDatarate = Nvm.MacGroup2.ChannelsDatarateDefault;

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -1347,6 +1347,7 @@ typedef struct sMlmeIndication
  * \ref MIB_JOIN_ACCEPT_DELAY_1                  | YES | YES
  * \ref MIB_JOIN_ACCEPT_DELAY_2                  | YES | YES
  * \ref MIB_CHANNELS_DATARATE                    | YES | YES
+ * \ref MIB_CHANNELS_MIN_TX_DATARATE             | YES | NO
  * \ref MIB_CHANNELS_DEFAULT_DATARATE            | YES | YES
  * \ref MIB_CHANNELS_TX_POWER                    | YES | YES
  * \ref MIB_CHANNELS_DEFAULT_TX_POWER            | YES | YES
@@ -1643,6 +1644,14 @@ typedef enum eMib
      * LoRaWAN Regional Parameters V1.0.2rB
      */
     MIB_JOIN_ACCEPT_DELAY_2,
+    /*!
+     * Minimum Data rate of a channel
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB
+     *
+     * The possible values are region specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+     */
+    MIB_CHANNELS_MIN_TX_DATARATE,
     /*!
      * Default Data rate of a channel
      *
@@ -2047,6 +2056,12 @@ typedef union uMibParam
      * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_2
      */
     uint32_t JoinAcceptDelay2;
+    /*!
+     * Channels minimum tx data rate
+     *
+     * Related MIB type: \ref MIB_CHANNELS_MIN_TX_DATARATE
+     */
+    int8_t ChannelsMinTxDatarate;
     /*!
      * Channels data rate
      *


### PR DESCRIPTION
ADR allows end devices to adapt to degraded RF conditions by dropping
the datarate until the server responds with a downlink packet in
response to the ADRACKReq bit being set. In the case when the network
connection has been lost, ADR will reduce the tx datarate to the minimum
possible value, then take no further action.

By adding the ability to query the minimum possible tx datarate,
applications can detect when this condition has occured, and take
appropriate action to rectify it. This functionality must be integrated
into the stack as the minimum datarate depends on the current value of
UplinkDwellTime, which is not available externally.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>