### PR TITLE
Fix RtcMs2Tick conversion on SAMR34

### DIFF
--- a/src/boards/SAMR34/rtc-board.c
+++ b/src/boards/SAMR34/rtc-board.c
@@ -130,7 +130,7 @@ uint32_t RtcGetMinimumTimeout( void )
 
 uint32_t RtcMs2Tick( TimerTime_t milliseconds )
 {
-    return ( uint32_t )( milliseconds );
+    return ( uint32_t )( ( ( ( uint64_t )milliseconds ) << 10 ) / 1000 );
 }
 
 TimerTime_t RtcTick2Ms( uint32_t tick )


### PR DESCRIPTION
Fix issue mentioned here: https://github.com/Lora-net/LoRaMac-node/discussions/1045