### PR TITLE
Fixed class B multicast handling in LoRaMacClassBProcessMulticastSlot()

### DIFF
--- a/src/mac/LoRaMacClassB.c
+++ b/src/mac/LoRaMacClassB.c
@@ -1133,12 +1133,15 @@ static void LoRaMacClassBProcessMulticastSlot( void )
         case PINGSLOT_STATE_CALC_PING_OFFSET:
         {
             // Compute all offsets for every multicast slots
-            for( uint8_t i = 0; i < 4; i++ )
+            for( uint8_t i = 0; i < LORAMAC_MAX_MC_CTX; i++ )
             {
-                ComputePingOffset( Ctx.BeaconCtx.BeaconTime.Seconds,
-                                   cur->ChannelParams.Address,
-                                   cur->PingPeriod,
-                                   &( cur->PingOffset ) );
+                if( cur->ChannelParams.IsEnabled )
+                {
+                    ComputePingOffset( Ctx.BeaconCtx.BeaconTime.Seconds,
+                                       cur->ChannelParams.Address,
+                                       cur->PingPeriod,
+                                       &( cur->PingOffset ) );
+                }
                 cur++;
             }
             Ctx.MulticastSlotState = PINGSLOT_STATE_SET_TIMER;
@@ -1151,14 +1154,17 @@ static void LoRaMacClassBProcessMulticastSlot( void )
 
             for( uint8_t i = 0; i < LORAMAC_MAX_MC_CTX; i++ )
             {
-                // Calculate the next slot time for every multicast slot
-                if( CalcNextSlotTime( cur->PingOffset, cur->PingPeriod, cur->PingNb, &slotTime ) == true )
+                if( cur->ChannelParams.IsEnabled )
                 {
-                    if( ( multicastSlotTime == 0 ) || ( multicastSlotTime > slotTime ) )
+                    // Calculate the next slot time for every multicast slot
+                    if( CalcNextSlotTime( cur->PingOffset, cur->PingPeriod, cur->PingNb, &slotTime ) == true )
                     {
-                        // Update the slot time and the next multicast channel
-                        multicastSlotTime = slotTime;
-                        Ctx.PingSlotCtx.NextMulticastChannel = cur;
+                        if( ( multicastSlotTime == 0 ) || ( multicastSlotTime > slotTime ) )
+                        {
+                            // Update the slot time and the next multicast channel
+                            multicastSlotTime = slotTime;
+                            Ctx.PingSlotCtx.NextMulticastChannel = cur;
+                        }
                     }
                 }
                 cur++;


### PR DESCRIPTION
- if a channel is not enabled, do not compute ping offset in ComputePingOffset(), I was getting a situation with "modulo zero" leading to a hard fault with a *disabled* channel being passed to ComputePingOffset() in LoRaMacClassBProcessMulticastSlot().
- do not use hard-coded constant of 4 instead of LORAMAC_MAX_MC_CTX macro - if this macro is changed to for example 2, then a hard fault or out of bound array access situation can happen.