### PR TITLE
Fix a dutycycle-related deadlock in ScheduleTx

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2911,8 +2911,8 @@ static LoRaMacStatus_t ScheduleTx( bool allowDelayedTx )
                 MacCtx.MacState |= LORAMAC_TX_DELAYED;
                 TimerSetValue( &MacCtx.TxDelayedTimer, MacCtx.DutyCycleWaitTime );
                 TimerStart( &MacCtx.TxDelayedTimer );
+                return LORAMAC_STATUS_OK;
             }
-            return LORAMAC_STATUS_OK;
         }
         else
         {// State where the MAC cannot send a frame

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2901,17 +2901,21 @@ static LoRaMacStatus_t ScheduleTx( bool allowDelayedTx )
 
     if( status != LORAMAC_STATUS_OK )
     {
-        if( ( status == LORAMAC_STATUS_DUTYCYCLE_RESTRICTED ) &&
-            ( allowDelayedTx == true ) )
+        if( status == LORAMAC_STATUS_DUTYCYCLE_RESTRICTED )
         {
-            // Allow delayed transmissions. We have to allow it in case
-            // the MAC must retransmit a frame with the frame repetitions
             if( MacCtx.DutyCycleWaitTime != 0 )
-            {// Send later - prepare timer
-                MacCtx.MacState |= LORAMAC_TX_DELAYED;
-                TimerSetValue( &MacCtx.TxDelayedTimer, MacCtx.DutyCycleWaitTime );
-                TimerStart( &MacCtx.TxDelayedTimer );
-                return LORAMAC_STATUS_OK;
+            {
+                if( allowDelayedTx == true )
+                {
+                    // Allow delayed transmissions. We have to allow it in case
+                    // the MAC must retransmit a frame with the frame repetitions
+                    MacCtx.MacState |= LORAMAC_TX_DELAYED;
+                    TimerSetValue( &MacCtx.TxDelayedTimer, MacCtx.DutyCycleWaitTime );
+                    TimerStart( &MacCtx.TxDelayedTimer );
+                    return LORAMAC_STATUS_OK;
+                }
+                // Need to delay, but allowDelayedTx does not allow it
+                return status;
             }
         }
         else


### PR DESCRIPTION
If we get a "dutycycle restricted" status with a zero dutycycle wait time from `RegionNextChannel`, attempt to transmit the uplink message right away. There is no need to check whether delayed TX is allowed or start the delayed TX timer in this case.

Only abort with `LORAMAC_STATUS_DUTYCYCLE_RESTRICTED` if we actually get a non-zero dutycycle wait time with delayed transmissions prohibited.

The previous implementation deadlocks during uplink retransmissions in dutycycled bands. Upon leaving a dutycycle-enforced quiet period, `RegionNextChannel` may return `LORAMAC_STATUS_DUTYCYCLE_RESTRICTED` with a zero dutycycle wait time. `ScheduleTx` was programmed to forgo the creation of the delayed TX timer, thus never getting re-executed to complete the transmission. The MAC would be stuck in a busy state.

Closes #1288