### PR TITLE
Move LORAMAC[_FALLBACK]?_VERSION macros to the header file

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -48,18 +48,6 @@
 
 #include "LoRaMac.h"
 
-#ifndef LORAMAC_VERSION
-/*!
- * LoRaWAN version definition.
- */
-#define LORAMAC_VERSION                             0x01010100
-#endif
-
-/*!
- * LoRaWAN fallback version definition.
- */
-#define LORAMAC_FALLBACK_VERSION                    0x01000400
-
 /*!
  * Maximum PHY layer payload size
  */

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -83,6 +83,18 @@ extern "C"
 #include "secure-element-nvm.h"
 #include "LoRaMacClassBNvm.h"
 
+#ifndef LORAMAC_VERSION
+/*!
+ * LoRaWAN version definition.
+ */
+#define LORAMAC_VERSION                             0x01010100
+#endif
+
+/*!
+ * LoRaWAN fallback version definition.
+ */
+#define LORAMAC_FALLBACK_VERSION                    0x01000400
+
 /*!
  * Maximum number of times the MAC layer tries to get an acknowledge.
  */

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -83,12 +83,10 @@ extern "C"
 #include "secure-element-nvm.h"
 #include "LoRaMacClassBNvm.h"
 
-#ifndef LORAMAC_VERSION
 /*!
  * LoRaWAN version definition.
  */
 #define LORAMAC_VERSION                             0x01010100
-#endif
 
 /*!
  * LoRaWAN fallback version definition.


### PR DESCRIPTION
This trivial change makes the two version values accessible to the application using LoRaMac-node. Being able to obtain the most recent supported MAC version is useful in case the application needs to generate data, e.g., for backend (TTN) provisioning.

Fixes #1285