### PR TITLE
Implement McpsRetransmit primitive to notify the application of uplink retransmissions

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3442,6 +3442,11 @@ LoRaMacStatus_t SendFrameOnChannel( uint8_t channel )
     // Send now
     Radio.Send( MacCtx.PktBuffer, MacCtx.PktBufferLen );
 
+    if(MacCtx.ChannelsNbTransCounter != 1 && MacCtx.MacPrimitives->MacMcpsRetransmit != NULL)
+    {
+        MacCtx.MacPrimitives->MacMcpsRetransmit( );
+    }
+
     return LORAMAC_STATUS_OK;
 }
 

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -2551,6 +2551,12 @@ typedef struct sLoRaMacPrimitives
      */
     void ( *MacMcpsConfirm )( McpsConfirm_t* McpsConfirm );
     /*!
+     * \brief   MCPS-Retransmit primitive
+     *
+     * \param   [OUT] MCPS-Retransmit parameters
+     */
+    void ( *MacMcpsRetransmit )( void );
+    /*!
      * \brief   MCPS-Indication primitive
      *
      * \param   [OUT] MCPS-Indication parameters


### PR DESCRIPTION
I am working on an application that needs to be notified of uplink retransmissions. Since I haven't found a way to obtain retransmission notifications from vanilla LoRaMac-node, I  have created a new primitive called `McpsRetransmit` that is invoked by the MAC on each retransmission.

This is a draft PR to solicit feedback from LoRaMac-node authors. If you would like to include such functionality in LoRaMac-node, please feel free to merge the PR, or let me know if you would like to have this implemented in some other way. I am not overly attached to the current implementation.