### PR TITLE
When restoring MAC state from NVM, update the sync word configured in the LoRa radio

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3390,6 +3390,11 @@ LoRaMacStatus_t RestoreNvmData( LoRaMacNvmData_t* nvm )
         MacCtx.RxWindowCConfig.DownlinkDwellTime = Nvm.MacGroup2.MacParams.DownlinkDwellTime;
         MacCtx.RxWindowCConfig.RxContinuous = true;
         MacCtx.RxWindowCConfig.RxSlot = RX_SLOT_WIN_CLASS_C;
+
+        // The public/private network flag may change upon reloading MacGroup2
+        // from NVM and we thus need to synchronize the radio. The same function
+        // is invoked in LoRaMacInitialiazation.
+        Radio.SetPublicNetwork( Nvm.MacGroup2.PublicNetwork );
     }
 
     // Secure Element


### PR DESCRIPTION
When LoRaMac-node restores its state from NVM, it also needs to reconfigure the sync word previously configured in the LoRa radio by LoRaMacInitialization.