### PR TITLE
Make Join duty cycling configurable for testing purposes.

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -847,6 +847,7 @@ static void ProcessRadioTxDone( void )
     txDone.ElapsedTimeSinceStartUp = SysTimeSub( SysTimeGetMcuTime( ), Nvm.MacGroup2.InitializationTime );
     txDone.LastTxAirTime = MacCtx.TxTimeOnAir;
     txDone.Joined  = true;
+    txDone.JoinDutyCycleEnabled = Nvm.MacGroup2.JoinDutyCycleOn;
     if( Nvm.MacGroup2.NetworkActivation == ACTIVATION_TYPE_NONE )
     {
         txDone.Joined  = false;
@@ -2883,6 +2884,7 @@ static LoRaMacStatus_t ScheduleTx( bool allowDelayedTx )
     nextChan.AggrTimeOff = Nvm.MacGroup1.AggregatedTimeOff;
     nextChan.Datarate = Nvm.MacGroup1.ChannelsDatarate;
     nextChan.DutyCycleEnabled = Nvm.MacGroup2.DutyCycleOn;
+    nextChan.JoinDutyCycleEnabled = Nvm.MacGroup2.JoinDutyCycleOn;
     nextChan.ElapsedTimeSinceStartUp = SysTimeSub( SysTimeGetMcuTime( ), Nvm.MacGroup2.InitializationTime );
     nextChan.LastAggrTx = Nvm.MacGroup1.LastTxDoneTime;
     nextChan.LastTxIsJoinRequest = false;
@@ -3643,6 +3645,9 @@ LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t* primitives, LoRaMacC
     params.NvmGroup2 = &Nvm.RegionGroup2;
     params.Bands = &RegionBands;
     RegionInitDefaults( Nvm.MacGroup2.Region, &params );
+
+    // Enable Join duty cycling by default
+    Nvm.MacGroup2.JoinDutyCycleOn = true;
 
     // Reset to defaults
     getPhy.Attribute = PHY_DUTY_CYCLE;
@@ -5374,6 +5379,12 @@ void LoRaMacTestSetDutyCycleOn( bool enable )
     {
         Nvm.MacGroup2.DutyCycleOn = enable;
     }
+}
+
+void LoRaMacTestSetJoinDutyCycleOn( bool enable )
+{
+    Nvm.MacGroup2.JoinDutyCycleOn = enable;
+    MacCtx.MacFlags.Bits.NvmHandle = 1;
 }
 
 LoRaMacStatus_t LoRaMacDeInitialization( void )

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -669,6 +669,10 @@ typedef struct sLoRaMacNvmDataGroup2
     * Enables/Disables duty cycle management (Test only)
     */
     bool DutyCycleOn;
+    /*!
+     * Enables/disables Join duty cycle management (Test only)
+     */
+    bool JoinDutyCycleOn;
     /*
      * Set to true, if the datarate was increased
      * with a link adr request.

--- a/src/mac/LoRaMacTest.h
+++ b/src/mac/LoRaMacTest.h
@@ -51,6 +51,16 @@ extern "C"
  */
 void LoRaMacTestSetDutyCycleOn( bool enable );
 
+/*!
+ * \brief   Enables or disables the Join duty cycle
+ *
+ * \details This is a test function. It shall be used for testing purposes only.
+ *          Changing this attribute may lead to a non-conformance LoRaMac operation.
+ *
+ * \param   [IN] enable - Enabled or disables the Join duty cycle
+ */
+void LoRaMacTestSetJoinDutyCycleOn( bool enable );
+
 /*! \} defgroup LORAMACTEST */
 
 #ifdef __cplusplus

--- a/src/mac/region/Region.h
+++ b/src/mac/region/Region.h
@@ -450,6 +450,10 @@ typedef struct sSetBandTxDoneParams
      */
     uint8_t Channel;
     /*!
+     * JoinDutyCycleEnabled Set to true to enable Join duty cycling
+     */
+    bool JoinDutyCycleEnabled;
+    /*!
      * Joined Set to true, if the node has joined the network
      */
     bool Joined;
@@ -790,6 +794,10 @@ typedef struct sNextChanParams
      * Set to true, if the duty cycle is enabled, otherwise false.
      */
     bool DutyCycleEnabled;
+    /*!
+     * Set to true, if the Join duty cycle is enabled, otherwise false.
+     */
+    bool JoinDutyCycleEnabled;
     /*!
      * Elapsed time since the start of the node.
      */

--- a/src/mac/region/RegionAS923.c
+++ b/src/mac/region/RegionAS923.c
@@ -356,7 +356,8 @@ PhyParam_t RegionAS923GetPhyParam( GetPhyParams_t* getPhy )
 void RegionAS923SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionAS923InitDefaults( InitDefaultsParams_t* params )
@@ -890,6 +891,7 @@ LoRaMacStatus_t RegionAS923NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionAU915.c
+++ b/src/mac/region/RegionAU915.c
@@ -313,7 +313,8 @@ PhyParam_t RegionAU915GetPhyParam( GetPhyParams_t* getPhy )
 void RegionAU915SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionAU915InitDefaults( InitDefaultsParams_t* params )
@@ -829,6 +830,7 @@ LoRaMacStatus_t RegionAU915NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup1->ChannelsMaskRemaining;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionCN470.c
+++ b/src/mac/region/RegionCN470.c
@@ -538,7 +538,8 @@ PhyParam_t RegionCN470GetPhyParam( GetPhyParams_t* getPhy )
 void RegionCN470SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionCN470InitDefaults( InitDefaultsParams_t* params )
@@ -954,6 +955,7 @@ LoRaMacStatus_t RegionCN470NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup1->ChannelsMaskRemaining;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionCN779.c
+++ b/src/mac/region/RegionCN779.c
@@ -274,7 +274,8 @@ PhyParam_t RegionCN779GetPhyParam( GetPhyParams_t* getPhy )
 void RegionCN779SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionCN779InitDefaults( InitDefaultsParams_t* params )
@@ -791,6 +792,7 @@ LoRaMacStatus_t RegionCN779NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionCommon.h
+++ b/src/mac/region/RegionCommon.h
@@ -244,6 +244,10 @@ typedef struct sRegionCommonRxBeaconSetupParams
 typedef struct sRegionCommonCountNbOfEnabledChannelsParams
 {
     /*!
+     * Set to true if Join duty cycling is enabled
+     */
+    bool JoinDutyCycleEnabled;
+    /*!
      * Set to true, if the device is joined.
      */
     bool Joined;
@@ -420,15 +424,19 @@ void RegionCommonChanMaskCopy( uint16_t* channelsMaskDest, uint16_t* channelsMas
  *
  * \param [IN] lastTxAirTime The time on air of the last TX frame.
  *
+ * \param [IN] joinDutyCycleEnabled Set to true if join duty cycling is enabled.
+ *
  * \param [IN] joined Set to true if the device has joined.
  *
  * \param [IN] elapsedTimeSinceStartup Elapsed time since initialization.
  */
-void RegionCommonSetBandTxDone( Band_t* band, TimerTime_t lastTxAirTime, bool joined, SysTime_t elapsedTimeSinceStartup );
+void RegionCommonSetBandTxDone( Band_t* band, TimerTime_t lastTxAirTime, bool joinDutyCycleEnabled, bool joined, SysTime_t elapsedTimeSinceStartup );
 
 /*!
  * \brief Updates the time-offs of the bands.
  *        This is a generic function and valid for all regions.
+ *
+ * \param [IN] joinDutyCycleEnabled Set to true if join duty cycling is enabled
  *
  * \param [IN] joined Set to true, if the node has joined the network
  *
@@ -446,7 +454,7 @@ void RegionCommonSetBandTxDone( Band_t* band, TimerTime_t lastTxAirTime, bool jo
  *
  * \retval Returns the time which must be waited to perform the next uplink.
  */
-TimerTime_t RegionCommonUpdateBandTimeOff( bool joined, Band_t* bands,
+TimerTime_t RegionCommonUpdateBandTimeOff( bool joinDutyCycleEnabled, bool joined, Band_t* bands,
                                            uint8_t nbBands, bool dutyCycleEnabled,
                                            bool lastTxIsJoinRequest, SysTime_t elapsedTimeSinceStartup,
                                            TimerTime_t expectedTimeOnAir );

--- a/src/mac/region/RegionEU433.c
+++ b/src/mac/region/RegionEU433.c
@@ -274,7 +274,8 @@ PhyParam_t RegionEU433GetPhyParam( GetPhyParams_t* getPhy )
 void RegionEU433SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionEU433InitDefaults( InitDefaultsParams_t* params )
@@ -791,6 +792,7 @@ LoRaMacStatus_t RegionEU433NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionEU868.c
+++ b/src/mac/region/RegionEU868.c
@@ -299,7 +299,8 @@ PhyParam_t RegionEU868GetPhyParam( GetPhyParams_t* getPhy )
 void RegionEU868SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionEU868InitDefaults( InitDefaultsParams_t* params )
@@ -824,6 +825,7 @@ LoRaMacStatus_t RegionEU868NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionIN865.c
+++ b/src/mac/region/RegionIN865.c
@@ -274,7 +274,8 @@ PhyParam_t RegionIN865GetPhyParam( GetPhyParams_t* getPhy )
 void RegionIN865SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionIN865InitDefaults( InitDefaultsParams_t* params )
@@ -814,6 +815,7 @@ LoRaMacStatus_t RegionIN865NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionKR920.c
+++ b/src/mac/region/RegionKR920.c
@@ -294,7 +294,8 @@ PhyParam_t RegionKR920GetPhyParam( GetPhyParams_t* getPhy )
 void RegionKR920SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionKR920InitDefaults( InitDefaultsParams_t* params )
@@ -788,6 +789,7 @@ LoRaMacStatus_t RegionKR920NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionRU864.c
+++ b/src/mac/region/RegionRU864.c
@@ -275,7 +275,8 @@ PhyParam_t RegionRU864GetPhyParam( GetPhyParams_t* getPhy )
 void RegionRU864SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionRU864InitDefaults( InitDefaultsParams_t* params )
@@ -790,6 +791,7 @@ LoRaMacStatus_t RegionRU864NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup2->ChannelsMask;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;

--- a/src/mac/region/RegionUS915.c
+++ b/src/mac/region/RegionUS915.c
@@ -312,7 +312,8 @@ PhyParam_t RegionUS915GetPhyParam( GetPhyParams_t* getPhy )
 void RegionUS915SetBandTxDone( SetBandTxDoneParams_t* txDone )
 {
     RegionCommonSetBandTxDone( &RegionBands[RegionNvmGroup2->Channels[txDone->Channel].Band],
-                               txDone->LastTxAirTime, txDone->Joined, txDone->ElapsedTimeSinceStartUp );
+                               txDone->LastTxAirTime, txDone->JoinDutyCycleEnabled, txDone->Joined,
+                               txDone->ElapsedTimeSinceStartUp );
 }
 
 void RegionUS915InitDefaults( InitDefaultsParams_t* params )
@@ -827,6 +828,7 @@ LoRaMacStatus_t RegionUS915NextChannel( NextChanParams_t* nextChanParams, uint8_
 
     // Search how many channels are enabled
     countChannelsParams.Joined = nextChanParams->Joined;
+    countChannelsParams.JoinDutyCycleEnabled = nextChanParams->JoinDutyCycleEnabled;
     countChannelsParams.Datarate = nextChanParams->Datarate;
     countChannelsParams.ChannelsMask = RegionNvmGroup1->ChannelsMaskRemaining;
     countChannelsParams.Channels = RegionNvmGroup2->Channels;


### PR DESCRIPTION
The library already provides a function that can be used to enable or disable band/region duty cycling for testing purposes. I would like to propose adding a similar function that could be used to enable or disable the additional duty cycling (back off) that is enforced for OTAA Join requests.

This PR consists of two commits. The first commits modifies the various region-specific files to add an additional parameter that could be used to enable or disable Join duty cycling. The second commit then adds a new variable to Nvm.MacGroup2 and implements a new function called `LoRaMacTestSetDutyCycleOn` that could be used to toggle the variable.

`LoRaMacTestSetDutyCycleOn` is inspired by `LoRaMacTestDutyCycleOn`. `Nvm.MacGroup2.JoinDutyCycleOn` is inspired by `Nvm.MacGroup2.DutyCycleOn`.