### PR TITLE
Fixes for class C activation and deactivation

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3838,6 +3838,10 @@ LoRaMacStatus_t LoRaMacStop( void )
 {
     if( LoRaMacIsBusy( ) == false )
     {
+        if( Nvm.MacGroup2.DeviceClass == CLASS_C )
+        {
+            Radio.Sleep( );
+        }
         MacCtx.MacState = LORAMAC_STOPPED;
         return LORAMAC_STATUS_OK;
     }

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3830,6 +3830,7 @@ LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t* primitives, LoRaMacC
 LoRaMacStatus_t LoRaMacStart( void )
 {
     MacCtx.MacState = LORAMAC_IDLE;
+    UpdateRxSlotIdleState();
     return LORAMAC_STATUS_OK;
 }
 

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2018,6 +2018,9 @@ static LoRaMacStatus_t SwitchClass( DeviceClass_t deviceClass )
         {
             if( deviceClass == CLASS_A )
             {
+                // Reset RxSlot to NONE
+                MacCtx.RxSlot = RX_SLOT_NONE;
+
                 Nvm.MacGroup2.DeviceClass = deviceClass;
 
                 // Set the radio into sleep to setup a defined state


### PR DESCRIPTION
This PR includes a few fixes for class C MAC operation:

- Make sure the radio is switched to continuous RX when starting in class C;
- Put the radio to sleep when stopping the MAC while it is operating in class C;
- Make sure continuous RX is not re-activated when switching from class C to class A.

Closes #1322 
Closes #1323