### PR TITLE
Teach LoRaMacIsBusy return false if the MAC is stopped

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -1504,6 +1504,11 @@ static void LoRaMacHandleIrqEvents( void )
 
 bool LoRaMacIsBusy( void )
 {
+    if( MacCtx.MacState == LORAMAC_STOPPED )
+    {
+        return false;
+    }
+
     if( LoRaMacRadioEvents.Events.RxProcessPending == 1 )
     {
         return true;


### PR DESCRIPTION
The previous version of LoRaMacIsBusy returned true when invoked while
the MAC is stopped. I believe this is incorrect. The MAC should not
indicate that is is busy while it is stopped.