### PR TITLE
Move AdrAckLimit and AdrAckDelay to NVM MacGroup2

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -4120,6 +4120,11 @@ LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t* mibGet )
             mibGet->Param.AdrAckLimit = MacCtx.AdrAckLimit;
             break;
         }
+        case MIB_ADR_ACK_DELAY:
+        {
+            mibGet->Param.AdrAckDelay = MacCtx.AdrAckDelay;
+            break;
+        }
         default:
         {
             status = LoRaMacClassBMibGetRequestConfirm( mibGet );
@@ -4794,6 +4799,11 @@ LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t* mibSet )
         case MIB_ADR_ACK_LIMIT:
         {
             MacCtx.AdrAckLimit = mibSet->Param.AdrAckLimit;
+            break;
+        }
+        case MIB_ADR_ACK_DELAY:
+        {
+            MacCtx.AdrAckDelay = mibSet->Param.AdrAckDelay;
             break;
         }
         default:

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -4115,6 +4115,11 @@ LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t* mibGet )
             mibGet->Param.Rejoin2CycleInSec = Nvm.MacGroup2.Rejoin2CycleInSec;
             break;
         }
+        case MIB_ADR_ACK_LIMIT:
+        {
+            mibGet->Param.AdrAckLimit = MacCtx.AdrAckLimit;
+            break;
+        }
         default:
         {
             status = LoRaMacClassBMibGetRequestConfirm( mibGet );
@@ -4784,6 +4789,11 @@ LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t* mibSet )
             {
                 status = LORAMAC_STATUS_PARAMETER_INVALID;
             }
+            break;
+        }
+        case MIB_ADR_ACK_LIMIT:
+        {
+            MacCtx.AdrAckLimit = mibSet->Param.AdrAckLimit;
             break;
         }
         default:

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -3048,6 +3048,8 @@ static void ResetMacParameters( void )
     Nvm.MacGroup2.MacParams.DownlinkDwellTime = Nvm.MacGroup2.MacParamsDefaults.DownlinkDwellTime;
     Nvm.MacGroup2.MacParams.MaxEirp = Nvm.MacGroup2.MacParamsDefaults.MaxEirp;
     Nvm.MacGroup2.MacParams.AntennaGain = Nvm.MacGroup2.MacParamsDefaults.AntennaGain;
+    Nvm.MacGroup2.MacParams.AdrAckLimit = Nvm.MacGroup2.MacParamsDefaults.AdrAckLimit;
+    Nvm.MacGroup2.MacParams.AdrAckDelay = Nvm.MacGroup2.MacParamsDefaults.AdrAckDelay;
 
     MacCtx.NodeAckRequested = false;
     Nvm.MacGroup1.SrvAckRequested = false;
@@ -3739,8 +3741,6 @@ LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t* primitives, LoRaMacC
     Nvm.MacGroup2.MacParams.JoinAcceptDelay1 = Nvm.MacGroup2.MacParamsDefaults.JoinAcceptDelay1;
     Nvm.MacGroup2.MacParams.JoinAcceptDelay2 = Nvm.MacGroup2.MacParamsDefaults.JoinAcceptDelay2;
     Nvm.MacGroup2.MacParams.ChannelsNbTrans = Nvm.MacGroup2.MacParamsDefaults.ChannelsNbTrans;
-    Nvm.MacGroup2.MacParams.AdrAckLimit = Nvm.MacGroup2.MacParamsDefaults.AdrAckLimit;
-    Nvm.MacGroup2.MacParams.AdrAckDelay = Nvm.MacGroup2.MacParamsDefaults.AdrAckDelay;
 
     // FPort 224 is enabled by default.
     Nvm.MacGroup2.IsCertPortOn = true;

--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -4118,6 +4118,16 @@ LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t* mibGet )
             mibGet->Param.AdrAckDelay = Nvm.MacGroup2.MacParams.AdrAckDelay;
             break;
         }
+        case MIB_ADR_ACK_DEFAULT_LIMIT:
+        {
+            mibGet->Param.AdrAckLimit = Nvm.MacGroup2.MacParamsDefaults.AdrAckLimit;
+            break;
+        }
+        case MIB_ADR_ACK_DEFAULT_DELAY:
+        {
+            mibGet->Param.AdrAckDelay = Nvm.MacGroup2.MacParamsDefaults.AdrAckDelay;
+            break;
+        }
         default:
         {
             status = LoRaMacClassBMibGetRequestConfirm( mibGet );
@@ -4797,6 +4807,16 @@ LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t* mibSet )
         case MIB_ADR_ACK_DELAY:
         {
             Nvm.MacGroup2.MacParams.AdrAckDelay = mibSet->Param.AdrAckDelay;
+            break;
+        }
+        case MIB_ADR_ACK_DEFAULT_LIMIT:
+        {
+            Nvm.MacGroup2.MacParamsDefaults.AdrAckLimit = mibSet->Param.AdrAckLimit;
+            break;
+        }
+        case MIB_ADR_ACK_DEFAULT_DELAY:
+        {
+            Nvm.MacGroup2.MacParamsDefaults.AdrAckDelay = mibSet->Param.AdrAckDelay;
             break;
         }
         default:

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -1449,6 +1449,8 @@ typedef struct sMlmeIndication
  * \ref MIB_REJOIN_2_CYCLE                       | YES | NO
  * \ref MIB_ADR_ACK_LIMIT                        | YES | YES
  * \ref MIB_ADR_ACK_DELAY                        | YES | YES
+ * \ref MIB_ADR_ACK_DEFAULT_LIMIT                | YES | YES
+ * \ref MIB_ADR_ACK_DEFAULT_DELAY                | YES | YES
  *
  * The following table provides links to the function implementations of the
  * related MIB primitives:
@@ -1889,6 +1891,14 @@ typedef enum eMib
       * ADR ack delay value
       */
      MIB_ADR_ACK_DELAY,
+     /*!
+      * ADR ack default limit value
+      */
+     MIB_ADR_ACK_DEFAULT_LIMIT,
+     /*!
+      * ADR ack default delay value
+      */
+     MIB_ADR_ACK_DEFAULT_DELAY,
 }Mib_t;
 
 /*!
@@ -2338,13 +2348,13 @@ typedef union uMibParam
     /*!
      * ADR ack limit value
      *
-     * Related MIB type: \ref MIB_ADR_ACK_LIMIT
+     * Related MIB types: \ref MIB_ADR_ACK_LIMIT, MIB_ADR_ACK_DEFAULT_LIMIT
      */
     uint16_t AdrAckLimit;
     /*!
      * ADR ack delay value
      *
-     * Related MIB type: \ref MIB_ADR_ACK_DELAY
+     * Related MIB types: \ref MIB_ADR_ACK_DELAY, MIB_ADR_ACK_DEFAULT_DELAY
      */
     uint16_t AdrAckDelay;
 }MibParam_t;

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -1438,6 +1438,7 @@ typedef struct sMlmeIndication
  * \ref MIB_REJOIN_1_CYCLE                       | YES | YES
  * \ref MIB_REJOIN_2_CYCLE                       | YES | NO
  * \ref MIB_ADR_ACK_LIMIT                        | YES | YES
+ * \ref MIB_ADR_ACK_DELAY                        | YES | YES
  *
  * The following table provides links to the function implementations of the
  * related MIB primitives:
@@ -1874,6 +1875,10 @@ typedef enum eMib
       * ADR ack limit value
       */
      MIB_ADR_ACK_LIMIT,
+     /*!
+      * ADR ack delay value
+      */
+     MIB_ADR_ACK_DELAY,
 }Mib_t;
 
 /*!
@@ -2326,6 +2331,12 @@ typedef union uMibParam
      * Related MIB type: \ref MIB_ADR_ACK_LIMIT
      */
     uint16_t AdrAckLimit;
+    /*!
+     * ADR ack delay value
+     *
+     * Related MIB type: \ref MIB_ADR_ACK_DELAY
+     */
+    uint16_t AdrAckDelay;
 }MibParam_t;
 
 /*!

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -312,6 +312,16 @@ typedef struct sLoRaMacParams
      * Antenna gain of the node
      */
     float AntennaGain;
+    /*!
+     * Limit of uplinks without any donwlink response before the ADRACKReq bit
+     * will be set.
+     */
+    uint16_t AdrAckLimit;
+    /*!
+     * Limit of uplinks without any donwlink response after a the first frame
+     * with set ADRACKReq bit before the trying to regain the connectivity.
+     */
+    uint16_t AdrAckDelay;
 }LoRaMacParams_t;
 
 /*!

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -1437,6 +1437,7 @@ typedef struct sMlmeIndication
  * \ref MIB_REJOIN_0_CYCLE                       | YES | YES
  * \ref MIB_REJOIN_1_CYCLE                       | YES | YES
  * \ref MIB_REJOIN_2_CYCLE                       | YES | NO
+ * \ref MIB_ADR_ACK_LIMIT                        | YES | YES
  *
  * The following table provides links to the function implementations of the
  * related MIB primitives:
@@ -1869,6 +1870,10 @@ typedef enum eMib
       * LoRaWAN certification FPort handling state (ON/OFF)
       */
      MIB_IS_CERT_FPORT_ON,
+     /*!
+      * ADR ack limit value
+      */
+     MIB_ADR_ACK_LIMIT,
 }Mib_t;
 
 /*!
@@ -2315,6 +2320,12 @@ typedef union uMibParam
      * Related MIB type: \ref MIB_IS_CERT_FPORT_ON
      */
     bool IsCertPortOn;
+    /*!
+     * ADR ack limit value
+     *
+     * Related MIB type: \ref MIB_ADR_ACK_LIMIT
+     */
+    uint16_t AdrAckLimit;
 }MibParam_t;
 
 /*!


### PR DESCRIPTION
This pull request moves the parameters AdrAckLimit and AdrAckDelay from the internal MacCtx data structure to NVM. The values are stored in `Nvm.MacGroup2.MacParams` and `Nvm.MacGroup2.MacParams` and are initialized in LoRaMacInitialization just like any other parameters initialized from the regional parameters and backed by the NVM.

This pull request also adds four new MIB types that can be used to get and set NVM-backed parameters:
- `MIB_ADR_ACK_LIMIT`
- `MIB_ADR_ACK_DELAY`
- `MIB_ADR_ACK_DEFAULT_LIMIT`
- `MIB_ADR_ACK_DEFAULT_DELAY`

Related to #1337
Closes #1341