### PR TITLE
Don't memset the TXRX buffer when radio is set to receive mode

### DIFF
--- a/src/radio/sx1272/sx1272.c
+++ b/src/radio/sx1272/sx1272.c
@@ -901,8 +901,6 @@ void SX1272SetRx( uint32_t timeout )
         break;
     }
 
-    memset( RxTxBuffer, 0, ( size_t )RX_TX_BUFFER_SIZE );
-
     SX1272.Settings.State = RF_RX_RUNNING;
     if( timeout != 0 )
     {

--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -1034,8 +1034,6 @@ void SX1276SetRx( uint32_t timeout )
         break;
     }
 
-    memset( RxTxBuffer, 0, ( size_t )RX_TX_BUFFER_SIZE );
-
     SX1276.Settings.State = RF_RX_RUNNING;
     if( timeout != 0 )
     {


### PR DESCRIPTION
The 1262 doesn't do this memset, but the 1272/1276 do.
This means, in an interrupt, if the radio is put back in RX mode before the payload is extracted and handed to a callback, it is zero'd.
This causes bugs like https://github.com/zephyrproject-rtos/zephyr/pull/48765 
They would prefer it be fixed here, as it is just a waste anyway - we don't do this in 1262, and don't need to do it here.