### PR TITLE
Fix/fragmentation

### DIFF
--- a/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
@@ -336,6 +336,12 @@ int32_t FragDecoderProcess( uint16_t fragCounter, uint8_t *rawData )
 
         // Update the FragDecoder.FragNbMissingIndex with the loosing frame
         FragFindMissingFrags( fragCounter );
+
+        if( FragDecoder.Status.FragNbLost == 0 && fragCounter == FragDecoder.FragNb)
+        { 
+            // the case : all the M(FragNb) first rows have been transmitted with no error
+            return FragDecoder.Status.FragNbLost;
+        }
     }
     else
     {
@@ -349,12 +355,6 @@ int32_t FragDecoderProcess( uint16_t fragCounter, uint8_t *rawData )
 
         // In case of the end of true data is missing
         FragFindMissingFrags( fragCounter );
-
-        if( FragDecoder.Status.FragNbLost == 0 )
-        { 
-            // the case : all the M(FragNb) first rows have been transmitted with no error
-            return FragDecoder.Status.FragNbLost;
-        }
 
         // fragCounter - FragDecoder.FragNb
         FragGetParityMatrixRow( fragCounter - FragDecoder.FragNb, FragDecoder.FragNb, matrixRow );

--- a/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/FragDecoder.c
@@ -337,7 +337,7 @@ int32_t FragDecoderProcess( uint16_t fragCounter, uint8_t *rawData )
         // Update the FragDecoder.FragNbMissingIndex with the loosing frame
         FragFindMissingFrags( fragCounter );
 
-        if( FragDecoder.Status.FragNbLost == 0 && fragCounter == FragDecoder.FragNb)
+        if( ( FragDecoder.Status.FragNbLost == 0 ) && ( fragCounter == FragDecoder.FragNb ) )
         { 
             // the case : all the M(FragNb) first rows have been transmitted with no error
             return FragDecoder.Status.FragNbLost;

--- a/src/apps/LoRaMac/common/LmHandler/packages/LmhpFragmentation.c
+++ b/src/apps/LoRaMac/common/LmHandler/packages/LmhpFragmentation.c
@@ -467,23 +467,20 @@ static void LmhpFragmentationOnMcpsIndication( McpsIndication_t *mcpsIndication 
                                                              FragSessionData[fragIndex].FragDecoderStatus.FragNbLost );
                     }
                 }
-                else
+                if( FragSessionData[fragIndex].FragDecoderProcessStatus >= 0 )
                 {
-                    if( FragSessionData[fragIndex].FragDecoderProcessStatus >= 0 )
+                    // Fragmentation successfully done
+                    FragSessionData[fragIndex].FragDecoderProcessStatus = FRAG_SESSION_NOT_STARTED;
+                    if( LmhpFragmentationParams->OnDone != NULL )
                     {
-                        // Fragmentation successfully done
-                        FragSessionData[fragIndex].FragDecoderProcessStatus = FRAG_SESSION_NOT_STARTED;
-                        if( LmhpFragmentationParams->OnDone != NULL )
-                        {
 #if( FRAG_DECODER_FILE_HANDLING_NEW_API == 1 )
-                            LmhpFragmentationParams->OnDone( FragSessionData[fragIndex].FragDecoderProcessStatus,
-                                                            ( FragSessionData[fragIndex].FragGroupData.FragNb * FragSessionData[fragIndex].FragGroupData.FragSize ) - FragSessionData[fragIndex].FragGroupData.Padding );
+                        LmhpFragmentationParams->OnDone( FragSessionData[fragIndex].FragDecoderProcessStatus,
+                                                        ( FragSessionData[fragIndex].FragGroupData.FragNb * FragSessionData[fragIndex].FragGroupData.FragSize ) - FragSessionData[fragIndex].FragGroupData.Padding );
 #else
-                            LmhpFragmentationParams->OnDone( FragSessionData[fragIndex].FragDecoderProcessStatus,
-                                                            LmhpFragmentationParams->Buffer,
-                                                            ( FragSessionData[fragIndex].FragGroupData.FragNb * FragSessionData[fragIndex].FragGroupData.FragSize ) - FragSessionData[fragIndex].FragGroupData.Padding );
+                        LmhpFragmentationParams->OnDone( FragSessionData[fragIndex].FragDecoderProcessStatus,
+                                                        LmhpFragmentationParams->Buffer,
+                                                        ( FragSessionData[fragIndex].FragGroupData.FragNb * FragSessionData[fragIndex].FragGroupData.FragSize ) - FragSessionData[fragIndex].FragGroupData.Padding );
 #endif
-                        }
                     }
                 }
                 cmdIndex += FragSessionData[fragIndex].FragGroupData.FragSize;


### PR DESCRIPTION
@mluis1  @martinichka 
Two problems are solved:
 
* Problem 1: (`LmhpFragmentation.c`) A minimum of 1 extra fragment was always needed, otherwise the decoder does not announce decoding is finished. To solve the issue "else" is deleted. 

* Problem 2: (FragDecoder.c) If all the original (uncoded) fragments are received, an extra coded fragment was needed to change the status of decoding procedure.