### PR TITLE
Allow USE_LRWAN_1_1_X_CRYPTO to be defined outside this header

### DIFF
--- a/src/mac/LoRaMacCrypto.h
+++ b/src/mac/LoRaMacCrypto.h
@@ -53,7 +53,9 @@ extern "C"
 /*!
  * Indicates if LoRaWAN 1.1.x crypto scheme is enabled
  */
+#ifndef USE_LRWAN_1_1_X_CRYPTO
 #define USE_LRWAN_1_1_X_CRYPTO                      1
+#endif
 
 /*!
  * Indicates if a random devnonce must be used or not


### PR DESCRIPTION
Hi,

Please consider this trivial change to allow the USE_LRWAN_1_1_X_CRYPTO value to be disabled outside of the src/mac/LoRaMacCrypto.h header file. We appreciate that enabling this improves the network security, however we are currently unable to enable this in our deployment and are making every effort to stay with upstream libraries.

Thanks
Jonathan Gordon

EDIT: I completely misread the C code, so we don't actually need this change. I'm going to leave the PR open incase you decide it is worth adding :shrug: Feel free to delete.