### PR TITLE
Support LoRaWAN 1.1 with ATECC608A/B secure element

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ The `DevEUI`, `Pin` and `JoinEUI` can be changed by editing the `se-identity.h` 
 
 #### atecc608a-tnglora-se
 
-The *atecc608a-tnglora-se* abstraction implementation handles all the required exchanges with the ATECC608A-TNGLORA secure-element.
+The *atecc608a-tnglora-se* abstraction implementation handles all the required exchanges with the ATECC608A-TNGLORA and ATECC608B-TNGLORA secure-elements.
 
-ATECC608A-TNGLORA secure-element is always pre-provisioned and its contents can't be changed.
+This secure-element is always pre-provisioned and its contents can't be changed.
 
 ### Building Process
 

--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.c
@@ -3,7 +3,7 @@
  *
  * @brief     Secure Element hardware abstraction layer implementation
  *
- * @remark    Current implementation only supports LoRaWAN 1.0.x version
+ * @remark    Current implementation supports LoRaWAN 1.0.x and 1.1
  * 
  * @copyright Copyright (c) 2020 The Things Industries B.V.
  * 

--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.h
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se-hal.h
@@ -3,7 +3,7 @@
  *
  * @brief     Secure Element hardware abstraction layer
  *
- * @remark    Current implementation only supports LoRaWAN 1.0.x version
+ * @remark    Current implementation supports LoRaWAN 1.0.x and 1.1
  * 
  * @copyright Copyright (c) 2020 The Things Industries B.V.
  * 

--- a/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se.c
+++ b/src/peripherals/atecc608a-tnglora-se/atecc608a-tnglora-se.c
@@ -3,7 +3,7 @@
  *
  * @brief     ATECC608A-TNGLORA Secure Element hardware implementation
  *
- * @remark    Current implementation only supports LoRaWAN 1.0.x version
+ * @remark    Current implementation supports LoRaWAN 1.0.x and 1.1
  *
  * @copyright Copyright (c) 2020 The Things Industries B.V.
  *

--- a/src/peripherals/atecc608a-tnglora-se/se-identity.h
+++ b/src/peripherals/atecc608a-tnglora-se/se-identity.h
@@ -96,8 +96,7 @@ extern "C" {
  */
 #define TNGLORA_DEV_EUI_SLOT 10U
 #define TNGLORA_JOIN_EUI_SLOT 9U
-#define TNGLORA_APP_KEY_SLOT 0U
-#define TNGLORA_NWK_KEY_SLOT 0U
+#define TNGLORA_ROOT_KEYS_SLOT 0U
 #define TNGLORA_S_NWK_S_INT_KEY_SLOT 4U
 #define TNGLORA_F_NWK_S_INT_KEY_SLOT 5U
 #define TNGLORA_J_S_INT_KEY_SLOT 6U
@@ -106,7 +105,8 @@ extern "C" {
 #define TNGLORA_NWK_S_ENC_KEY_SLOT 3U
 #define TNGLORA_MC_APP_S_KEY_0_SLOT 11U
 #define TNGLORA_MC_NWK_S_KEY_0_SLOT 12U
-#define TNGLORA_APP_KEY_BLOCK_INDEX 1U
+#define TNGLORA_APP_KEY_BLOCK_INDEX 0U
+#define TNGLORA_NWK_KEY_BLOCK_INDEX 1U
 #define TNGLORA_REMAINING_KEYS_BLOCK_INDEX 0U
 
 #define ATECC608A_SE_KEY_LIST                                                                                          \
@@ -117,7 +117,7 @@ extern "C" {
              * WARNING: FOR 1.0.x DEVICES IT IS THE \ref LORAWAN_GEN_APP_KEY                                           \
              */                                                                                                        \
             .KeyID         = APP_KEY,                                                                                  \
-            .KeySlotNumber = TNGLORA_APP_KEY_SLOT,                                                                     \
+            .KeySlotNumber = TNGLORA_ROOT_KEYS_SLOT,                                                                     \
             .KeyBlockIndex = TNGLORA_APP_KEY_BLOCK_INDEX,                                                              \
         },                                                                                                             \
         {                                                                                                              \
@@ -126,12 +126,12 @@ extern "C" {
              * WARNING: FOR 1.0.x DEVICES IT IS THE \ref LORAWAN_APP_KEY                                               \
              */                                                                                                        \
             .KeyID         = NWK_KEY,                                                                                  \
-            .KeySlotNumber = TNGLORA_APP_KEY_SLOT,                                                                     \
-            .KeyBlockIndex = TNGLORA_APP_KEY_BLOCK_INDEX,                                                              \
+            .KeySlotNumber = TNGLORA_ROOT_KEYS_SLOT,                                                                     \
+            .KeyBlockIndex = TNGLORA_NWK_KEY_BLOCK_INDEX,                                                              \
         },                                                                                                             \
         {                                                                                                              \
             /*!                                                                                                        \
-             * Join session integrity key (Dynamically updated)                                                        \
+             * Join Server integrity key (Dynamically updated)                                                         \
              * WARNING: NOT USED FOR 1.0.x DEVICES                                                                     \
              */                                                                                                        \
             .KeyID         = J_S_INT_KEY,                                                                              \
@@ -140,7 +140,7 @@ extern "C" {
         },                                                                                                             \
         {                                                                                                              \
             /*!                                                                                                        \
-             * Join session encryption key (Dynamically updated)                                                       \
+             * Join Server encryption key (Dynamically updated)                                                        \
              * WARNING: NOT USED FOR 1.0.x DEVICES                                                                     \
              */                                                                                                        \
             .KeyID         = J_S_ENC_KEY,                                                                              \


### PR DESCRIPTION
This adds support for LoRaWAN 1.1 when using the ATECC608A/B secure element.

Before, the AppKey and NwkKey pointed to the same buffer, denoted by block index 0.

This library uses LoRaWAN 1.1 terminology; NwkKey is always used for network session key derivation, and also for application session key derivation in LoRaWAN 1.0.x. So, AppKey is only used in application session key derivation in LoRaWAN 1.1. This did not work, as AppKey was equal to NwkKey.

The diff is a bit confusing. Here is what happens:

Root key | Old block index | New block index
--- | --- | ---
NwkKey | `TNGLORA_APP_KEY_BLOCK_INDEX` = 1 | `TNGLORA_NWK_KEY_BLOCK_INDEX` = 1
AppKey | `TNGLORA_APP_KEY_BLOCK_INDEX` = 1 | `TNGLORA_APP_KEY_BLOCK_INDEX` = 0

Besides this, there are minor clarifications in the README and code comments.

cc @mluis1 @elsalahy 

Internal reference https://github.com/TheThingsIndustries/lorawan-join-server/issues/38
Internal reference https://github.com/TheThingsIndustries/lorawan-stack/pull/3483