### PR TITLE
fix bug

### DIFF
--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -849,7 +849,9 @@ void SX1276Send( uint8_t *buffer, uint8_t size )
                 SX1276Write( REG_LR_INVERTIQ, ( ( SX1276Read( REG_LR_INVERTIQ ) & RFLR_INVERTIQ_TX_MASK & RFLR_INVERTIQ_RX_MASK ) | RFLR_INVERTIQ_RX_OFF | RFLR_INVERTIQ_TX_OFF ) );
                 SX1276Write( REG_LR_INVERTIQ2, RFLR_INVERTIQ2_OFF );
             }
-
+            //fix bug
+            SX1276Write(REG_LR_HOPCHANNEL, 0);
+            
             SX1276.Settings.LoRaPacketHandler.Size = size;
 
             // Initializes the payload size


### PR DESCRIPTION
When LoRa sends a packet in fhss mode but does not receive the packet.  at this time, LoRa continues to send another packet, REG_ LR_ HOPCHANNEL has not been initialized but a value of 64 or 65. So, REG_ LR_ HOPCHANNEL need to be initialized in SX1276Send() function.