### PR TITLE
fix off by one after SRV_MAC_LINK_ADR_REQ when only one byte left

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -2276,11 +2276,8 @@ static void ProcessMacCommands( uint8_t *payload, uint8_t macIndex, uint8_t comm
 
                     } while( payload[macIndex++] == SRV_MAC_LINK_ADR_REQ );
 
-                    if( macIndex < commandsSize )
-                    {
-                        // Decrease the index such that it points to the next MAC command
-                        macIndex--;
-                    }
+                    // Decrease the index such that it points to the next MAC command
+                    macIndex--;
                 }
                 else
                 {


### PR DESCRIPTION
When the MAC command SRV_MAC_LINK_ADR_REQ is received followed by only one byte MAC command the last one byte command will not be processed. In this case the macIndex will not be corrected and the last byte is skipped.

I had this problem with a SRV_MAC_LINK_ADR_REQ command followed by a SRV_MAC_DEV_STATUS_REQ command.
