### PR TITLE
Fix register corruption due to colliding SPI transactions in FSK

### DIFF
--- a/src/radio/sx1276/sx1276.c
+++ b/src/radio/sx1276/sx1276.c
@@ -1125,7 +1125,9 @@ static void SX1276SetTx( uint32_t timeout )
 
     SX1276.Settings.State = RF_TX_RUNNING;
     TimerStart( &TxTimeoutTimer );
+    CRITICAL_SECTION_BEGIN();
     SX1276SetOpMode( RF_OPMODE_TRANSMITTER );
+    CRITICAL_SECTION_END();
 }
 
 void SX1276StartCad( void )


### PR DESCRIPTION
Fix register corruption due to colliding SPI transactions in FSK

In FSK Tx, the Dio1 interrupt may already fire while the SPI transaction for SetOpMode is still in progress. This leads to registers 0x02 and further being overwritten with junk data.

This is solved by disabling interrupts for this specific SetOpMode call.

A more detailed discussion is posted on https://github.com/Lora-net/LoRaMac-node/discussions/1551