### PR TITLE
utilities: fix shadowed variables

### DIFF
--- a/src/boards/mcu/utilities.c
+++ b/src/boards/mcu/utilities.c
@@ -107,7 +107,7 @@ uint32_t Crc32( uint8_t *buffer, uint16_t length )
     for( uint16_t i = 0; i < length; ++i )
     {
         crc ^= ( uint32_t )buffer[i];
-        for( uint16_t i = 0; i < 8; i++ )
+        for( uint16_t j = 0; j < 8; i++ )
         {
             crc = ( crc >> 1 ) ^ ( reversedPolynom & ~( ( crc & 0x01 ) - 1 ) );
         }
@@ -137,7 +137,7 @@ uint32_t Crc32Update( uint32_t crcInit, uint8_t *buffer, uint16_t length )
     for( uint16_t i = 0; i < length; ++i )
     {
         crc ^= ( uint32_t )buffer[i];
-        for( uint16_t i = 0; i < 8; i++ )
+        for( uint16_t j = 0; j < 8; i++ )
         {
             crc = ( crc >> 1 ) ^ ( reversedPolynom & ~( ( crc & 0x01 ) - 1 ) );
         }

--- a/src/boards/utilities.h
+++ b/src/boards/utilities.h
@@ -183,6 +183,11 @@ uint32_t Crc32Finalize( uint32_t crc );
 #define CRITICAL_SECTION_BEGIN( ) uint32_t mask; BoardCriticalSectionBegin( &mask )
 
 /*!
+ * Begin repeated critical section
+ */
+#define CRITICAL_SECTION_BEGIN_REPEAT( ) BoardCriticalSectionBegin( &mask )
+
+/*!
  * Ends critical section
  */
 #define CRITICAL_SECTION_END( ) BoardCriticalSectionEnd( &mask )

--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -1261,7 +1261,7 @@ void RadioIrqProcess( void )
         SX126xClearIrqStatus( irqRegs );
 
         // Check if DIO1 pin is High. If it is the case revert IrqFired to true
-        CRITICAL_SECTION_BEGIN( );
+        CRITICAL_SECTION_BEGIN_REPEAT( );
         if( SX126xGetDio1PinState( ) == 1 )
         {
             IrqFired = true;


### PR DESCRIPTION
Fix shadowed variables in the radio driver and utility functions.

utilities.h:183:44: error: declaration of 'mask' shadows a previous local [-Werror=shadow]
  183 | #define CRITICAL_SECTION_BEGIN( ) uint32_t mask; BoardCritica...