### PR TITLE
mac: region: RegionCommon: fix implicit double promotion

### DIFF
--- a/src/mac/region/RegionCommon.c
+++ b/src/mac/region/RegionCommon.c
@@ -463,7 +463,7 @@ int8_t RegionCommonComputeTxPower( int8_t txPowerIndex, float maxEirp, float ant
 {
     int8_t phyTxPower = 0;
 
-    phyTxPower = ( int8_t )floor( ( maxEirp - ( txPowerIndex * 2U ) ) - antennaGain );
+    phyTxPower = ( int8_t )floorf( ( maxEirp - ( txPowerIndex * 2U ) ) - antennaGain );
 
     return phyTxPower;
 }


### PR DESCRIPTION
The calculation is done with float variables. However, the floor function is meant for double variables. floorf should be used instead.

The implicit double promotion leads to a warning/error if compiled with LLVM.