### PR TITLE
mac: make `LoRaMacPrimitives_t`, `LoRaMacCallback_t` pointers to `const`

### DIFF
--- a/src/mac/LoRaMac.c
+++ b/src/mac/LoRaMac.c
@@ -142,11 +142,11 @@ typedef struct sLoRaMacCtx
     /*
     * LoRaMac upper layer event functions
     */
-    LoRaMacPrimitives_t* MacPrimitives;
+    const LoRaMacPrimitives_t* MacPrimitives;
     /*
     * LoRaMac upper layer callback functions
     */
-    LoRaMacCallback_t* MacCallbacks;
+    const LoRaMacCallback_t* MacCallbacks;
     /*
     * Radio events function pointer
     */
@@ -3750,7 +3750,7 @@ static uint8_t IsRequestPending( void )
 }
 
 
-LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t* primitives, LoRaMacCallback_t* callbacks, LoRaMacRegion_t region )
+LoRaMacStatus_t LoRaMacInitialization( const LoRaMacPrimitives_t* primitives, const LoRaMacCallback_t* callbacks, LoRaMacRegion_t region )
 {
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;

--- a/src/mac/LoRaMac.h
+++ b/src/mac/LoRaMac.h
@@ -2634,7 +2634,7 @@ static const uint8_t LoRaMacMaxEirpTable[] = { 8, 10, 12, 13, 14, 16, 18, 20, 21
  *          \ref LORAMAC_STATUS_PARAMETER_INVALID,
  *          \ref LORAMAC_STATUS_REGION_NOT_SUPPORTED.
  */
-LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t* primitives, LoRaMacCallback_t* callbacks, LoRaMacRegion_t region );
+LoRaMacStatus_t LoRaMacInitialization( const LoRaMacPrimitives_t* primitives, const LoRaMacCallback_t* callbacks, LoRaMacRegion_t region );
 
 /*!
  * \brief   Starts LoRaMAC layer

--- a/src/mac/LoRaMacConfirmQueue.c
+++ b/src/mac/LoRaMacConfirmQueue.c
@@ -54,7 +54,7 @@ typedef struct sLoRaMacConfirmQueueCtx
     /*!
     * LoRaMac callback function primitives
     */
-    LoRaMacPrimitives_t* Primitives;
+    const LoRaMacPrimitives_t* Primitives;
     /*!
     * Pointer to the first element of the ring buffer
     */
@@ -143,7 +143,7 @@ static MlmeConfirmQueue_t* GetElement( Mlme_t request, MlmeConfirmQueue_t* buffe
     return NULL;
 }
 
-void LoRaMacConfirmQueueInit( LoRaMacPrimitives_t* primitives )
+void LoRaMacConfirmQueueInit( const LoRaMacPrimitives_t* primitives )
 {
     ConfirmQueueCtx.Primitives = primitives;
 

--- a/src/mac/LoRaMacConfirmQueue.h
+++ b/src/mac/LoRaMacConfirmQueue.h
@@ -83,7 +83,7 @@ typedef struct sMlmeConfirmQueue
  *
  * \param   [IN] primitives - Pointer to the LoRaMac primitives.
  */
-void LoRaMacConfirmQueueInit( LoRaMacPrimitives_t* primitive );
+void LoRaMacConfirmQueueInit( const LoRaMacPrimitives_t* primitive );
 
 /*!
  * \brief   Adds an element to the confirm queue.


### PR DESCRIPTION
Change `LoRaMacPrimitives_t`, `LoRaMacCallback_t` to `const*` to reflect read-only internal operations.

This also enables the caller to provide constant data without needing explicit casts to (`LoRaMacPrimitives_t*`) or (`LoRaMacCallback_t*`).