### PR TITLE
HARD FAULT : Add sanity check to sx126x driver when handling retention list

### DIFF
--- a/src/radio/sx126x/radio.c
+++ b/src/radio/sx126x/radio.c
@@ -1119,8 +1119,15 @@ void RadioAddRegisterToRetentionList( uint16_t registerAddress )
     // Read the address and registers already added to the list
     SX126xReadRegisters( REG_RETENTION_LIST_BASE_ADDRESS, buffer, 9 );
 
-    const uint8_t nbOfRegisters = buffer[0];
+    uint8_t nbOfRegisters = buffer[0];
     uint8_t* registerList   = &buffer[1];
+
+    // in case more than maximum read -> set to 0
+    if(nbOfRegisters > MAX_NB_REG_IN_RETENTION)
+    {
+        nbOfRegisters = 0;
+        buffer[0] = 0; // set also to zero - invalid value was read-out
+    }
 
     // Check if the register given as parameter is already added to the list
     for( uint8_t i = 0; i < nbOfRegisters; i++ )


### PR DESCRIPTION
The same as described here applies: https://github.com/Lora-net/SWL2001/pull/72
In one sentence - without the sanity check, reading ouf of bounds of an array placed on stack can happen -> this will cause reading outside of RAM/SRAM region, due to stack being placed at the end of SRAM/RAM region -> this will generate a hardfault or a memfault or take down the system...